### PR TITLE
CodeForces parser doesn't work with Russian interface

### DIFF
--- a/src/parsers/problem/CodeforcesProblemParser.ts
+++ b/src/parsers/problem/CodeforcesProblemParser.ts
@@ -70,7 +70,7 @@ export class CodeforcesProblemParser extends Parser {
       '.problem-statement > .header > .input-file',
     ).childNodes[1].textContent;
 
-    if (inputFile !== 'standard input') {
+    if (inputFile !== 'standard input' && inputFile !== 'стандартный ввод') {
       task.setInput({
         fileName: inputFile,
         type: 'file',
@@ -81,7 +81,7 @@ export class CodeforcesProblemParser extends Parser {
       '.problem-statement > .header > .output-file',
     ).childNodes[1].textContent;
 
-    if (outputFile !== 'standard output') {
+    if (outputFile !== 'standard output' && outputFile !== 'стандартный вывод') {
       task.setOutput({
         fileName: outputFile,
         type: 'file',


### PR DESCRIPTION
So, when you parse Codeforces problem in Russian interfaces, input/output is set to files called "стандартный ввод/стандартный вывод" (that is standard input/standard output in Russian).

Note, I made a patch how I think it could look like, **but I didn't test it** because I am not sure how to create environment for that. It may not work, for example, because of encoding issues.