### PR TITLE
Fix FacebookHackerCup parser

### DIFF
--- a/src/parsers/problem/FacebookHackerCupProblemParser.ts
+++ b/src/parsers/problem/FacebookHackerCupProblemParser.ts
@@ -24,7 +24,7 @@ export class FacebookHackerCupProblemParser extends Parser {
     const filename = task.name.toLowerCase().replace(/ /g, '_');
 
     task.setInput({
-      pattern: filename + '.txt',
+      fileName: filename + '.txt',
       type: 'file',
     });
 

--- a/tests/data/facebook-hacker-cup/problem/normal.json
+++ b/tests/data/facebook-hacker-cup/problem/normal.json
@@ -17,7 +17,7 @@
     "testType": "multiNumber",
     "input": {
       "type": "file",
-      "pattern": "boomerang_constellations.txt"
+      "fileName": "boomerang_constellations.txt"
     },
     "output": {
       "type": "file",


### PR DESCRIPTION
It seems the "pattern" attribute has been mistakenly left from and old version that supported regex. With no "fileName" attribute, CHelper fails to parse problems.