### PR TITLE
Support AtCoder problems written in Japanese

### DIFF
--- a/src/parsers/problem/AtCoderProblemParser.ts
+++ b/src/parsers/problem/AtCoderProblemParser.ts
@@ -27,13 +27,13 @@ export class AtCoderProblemParser extends Parser {
     task.setMemoryLimit(parseInt(/(\d+) ?MB/.exec(memoryLimitStr)[1], 10));
 
     const inputs = [...elem.querySelectorAll('h3')]
-      .filter(el => el.textContent.includes('Sample Input'))
+      .filter(el => el.textContent.includes('入力例'))
       .map(el =>
         el.nextElementSibling.tagName === 'DIV' ? el.nextElementSibling.nextElementSibling : el.nextElementSibling,
       );
 
     const outputs = [...elem.querySelectorAll('h3')]
-      .filter(el => el.textContent.includes('Sample Output'))
+      .filter(el => el.textContent.includes('出力例'))
       .map(el =>
         el.nextElementSibling.tagName === 'DIV' ? el.nextElementSibling.nextElementSibling : el.nextElementSibling,
       );

--- a/tests/data/atcoder/problem/normal_ja.json
+++ b/tests/data/atcoder/problem/normal_ja.json
@@ -1,0 +1,39 @@
+{
+  "url": "https://atcoder.jp/contests/colopl2018-final/tasks/colopl2018_final_a",
+  "parser": "problem/AtCoderProblemParser",
+  "result": {
+    "name": "A - ファイティング・タカハシ",
+    "group": "COLOCON -Colopl programming contest 2018- Final",
+    "url": "https://atcoder.jp/contests/colopl2018-final/tasks/colopl2018_final_a",
+    "interactive": false,
+    "memoryLimit": 256,
+    "timeLimit": 2000,
+    "tests": [
+      {
+        "input": "3\nABBAA\n",
+        "output": "16\n"
+      },
+      {
+        "input": "4\nABBAAABBAA\n",
+        "output": "46\n"
+      },
+      {
+        "input": "100\nAAABAAAABAAAAABBBBBBBBBAABBBBBBAAAAABBB\n",
+        "output": "4900\n"
+      }
+    ],
+    "testType": "single",
+    "input": {
+      "type": "stdin"
+    },
+    "output": {
+      "type": "stdout"
+    },
+    "languages": {
+      "java": {
+        "mainClass": "Main",
+        "taskClass": "A"
+      }
+    }
+  }
+}


### PR DESCRIPTION
Most of problems in AtCoder are written in English and Japanese, but some problems are written in Japanese only.
ex) https://atcoder.jp/contests/colopl2018-final/tasks/colopl2018_final_a

So I replaced `Sample Input` / `Sample Output` to `入力例` / `出力例` to be able to parse test cases for all problems.