### PR TITLE
Fix parsing time limits in ms in Toph parser

### DIFF
--- a/src/parsers/problem/TophProblemParser.ts
+++ b/src/parsers/problem/TophProblemParser.ts
@@ -16,10 +16,11 @@ export class TophProblemParser extends Parser {
 
     const limitsStr = elem.querySelector('.limits').textContent;
 
-    task.setTimeLimit(parseFloat(/([0-9.]+)s/.exec(limitsStr)[1]) * 1000);
+    const [, timeAmount, timeUnit] = /([0-9.]+)(.*),/.exec(limitsStr);
+    task.setTimeLimit(parseFloat(timeAmount) * (timeUnit === 'ms' ? 1 : 1000));
 
-    const [, amount, unit] = /, ([0-9.]+) (.*)/.exec(limitsStr);
-    task.setMemoryLimit(parseFloat(amount) * (unit === 'MB' ? 1 : 1024));
+    const [, memoryAmount, memoryUnit] = /, ([0-9.]+) (.*)/.exec(limitsStr);
+    task.setMemoryLimit(parseFloat(memoryAmount) * (memoryUnit === 'MB' ? 1 : 1024));
 
     elem.querySelectorAll('.table.samples').forEach(table => {
       const blocks = table.querySelectorAll('tbody > tr > td > pre');

--- a/tests/data/toph/problem/time-limit-in-ms.json
+++ b/tests/data/toph/problem/time-limit-in-ms.json
@@ -1,0 +1,35 @@
+{
+  "url": "https://toph.co/p/distinctness",
+  "parser": "problem/TophProblemParser",
+  "result": {
+    "name": "Distinctness",
+    "group": "Toph",
+    "url": "https://toph.co/p/distinctness",
+    "interactive": false,
+    "memoryLimit": 512,
+    "timeLimit": 500,
+    "tests": [
+      {
+        "input": "abcde\n",
+        "output": "1\n3\n6\n10\n15\n"
+      },
+      {
+        "input": "zx\n",
+        "output": "1\n3\n"
+      }
+    ],
+    "testType": "single",
+    "input": {
+      "type": "stdin"
+    },
+    "output": {
+      "type": "stdout"
+    },
+    "languages": {
+      "java": {
+        "mainClass": "Main",
+        "taskClass": "Distinctness"
+      }
+    }
+  }
+}


### PR DESCRIPTION
Toph parser didn't expect that time limit can be given in milliseconds.