### PR TITLE
Fix parsing Codeforces gym problems

### DIFF
--- a/src/parsers/problem/CodeforcesProblemParser.ts
+++ b/src/parsers/problem/CodeforcesProblemParser.ts
@@ -54,7 +54,8 @@ export class CodeforcesProblemParser extends Parser {
       breadcrumbs.pop();
       task.setCategory(breadcrumbs.join(' - '));
     } else {
-      task.setCategory(elem.querySelector('.rtable > tbody > tr > th > a[href*="/contest"]').textContent.trim());
+      const contestType = url.includes('/gym/') ? 'gym' : 'contest';
+      task.setCategory(elem.querySelector(`.rtable > tbody > tr > th > a[href*=${contestType}]`).textContent.trim());
     }
 
     const interactiveKeywords = ['Interaction', 'Протокол взаимодействия'];

--- a/tests/data/codeforces/problem/gym.json
+++ b/tests/data/codeforces/problem/gym.json
@@ -1,0 +1,32 @@
+{
+  "url": "https://codeforces.com/gym/101991/problem/E?locale=en",
+  "parser": "problem/CodeforcesProblemParser",
+  "result": {
+    "name": "E. Exciting Menus",
+    "group": "Codeforces - 2018 Arab Collegiate Programming Contest (ACPC 2018)",
+    "url": "https://codeforces.com/gym/101991/problem/E?locale=en",
+    "interactive": false,
+    "memoryLimit": 1024,
+    "timeLimit": 4000,
+    "tests": [
+      {
+        "input": "2\n2\naabaa\naa\n0 0 0 0 100\n0 1\n4\nbbbaa\naa\naab\naax\n0 0 0 0 100\n0 0\n0 0 0\n0 0 0\n",
+        "output": "500\n600\n"
+      }
+    ],
+    "testType": "single",
+    "input": {
+      "fileName": "exciting.in",
+      "type": "file"
+    },
+    "output": {
+      "type": "stdout"
+    },
+    "languages": {
+      "java": {
+        "mainClass": "Main",
+        "taskClass": "EExcitingMenus"
+      }
+    }
+  }
+}


### PR DESCRIPTION
In one of last commits was added "a[href*="/contest"]" to the path of querySelector. It works well in contests, but absolutely fails in gyms. To fix that we have to change "/contest" to "/gym" when we are in gym.

This bug was mentioned in #83