### PR TITLE
Add support for multiple test blocks in SPOJ parser

### DIFF
--- a/src/parsers/problem/SPOJProblemParser.ts
+++ b/src/parsers/problem/SPOJProblemParser.ts
@@ -24,7 +24,7 @@ export class SPOJProblemParser extends Parser {
     while (current !== null) {
       if (isExample && current.tagName === 'PRE') {
         blocks.push(current);
-      } else if (current.textContent === 'Example') {
+      } else if (current.textContent === 'Example' || current.textContent === 'Example Input') {
         isExample = true;
       }
 
@@ -35,11 +35,13 @@ export class SPOJProblemParser extends Parser {
       const lines = blocks[0].textContent.trim().split('\n');
       const [input, output] = this.parseTestDataSingleBlock(lines);
       task.addTest(input, output);
-    } else if (blocks.length === 2) {
-      const lines1 = blocks[0].textContent.trim().split('\n');
-      const lines2 = blocks[1].textContent.trim().split('\n');
-      const [input, output] = this.parseTestDataTwoBlocks(lines1, lines2);
-      task.addTest(input, output);
+    } else {
+      for (let i = 0; i < blocks.length; i += 2) {
+        const lines1 = blocks[i].textContent.trim().split('\n');
+        const lines2 = blocks[i + 1].textContent.trim().split('\n');
+        const [input, output] = this.parseTestDataTwoBlocks(lines1, lines2);
+        task.addTest(input, output);
+      }
     }
 
     const timeElems = elem.querySelectorAll('#problem-meta > tbody > tr');

--- a/tests/data/spoj/problem/multiple-blocks.json
+++ b/tests/data/spoj/problem/multiple-blocks.json
@@ -1,0 +1,47 @@
+{
+  "url": "https://www.spoj.com/problems/ADAPHOTO/",
+  "parser": "problem/SPOJProblemParser",
+  "result": {
+    "name": "Ada and Terramorphing",
+    "group": "SPOJ - Classical",
+    "url": "https://www.spoj.com/problems/ADAPHOTO/",
+    "interactive": false,
+    "memoryLimit": 1536,
+    "timeLimit": 2000,
+    "tests": [
+      {
+        "input": "-~^v-\n^--v\n",
+        "output": "1\n"
+      },
+      {
+        "input": "-~\n-~v^^^^^v-\n",
+        "output": "2\n"
+      },
+      {
+        "input": "~-~-v--~^\n~^--^~-v\n",
+        "output": "3\n"
+      },
+      {
+        "input": "^^^v-v^^v-v-v~v-\nvv^v-^~~^v^~^vv~^^-\n",
+        "output": "3\n"
+      },
+      {
+        "input": "~~~vv~-~~vv~v-v--~-^-~^~-^^\n~^~--v~-\n",
+        "output": "4\n"
+      }
+    ],
+    "testType": "single",
+    "input": {
+      "type": "stdin"
+    },
+    "output": {
+      "type": "stdout"
+    },
+    "languages": {
+      "java": {
+        "mainClass": "Main",
+        "taskClass": "AdaAndTerramorphing"
+      }
+    }
+  }
+}


### PR DESCRIPTION
SPOJ parser didn't parse tests when there are separate areas for each input and output and they start with "Example Input".