### PR TITLE
Add support for multiple test blocks in Google competitions

### DIFF
--- a/src/parsers/problem/GoogleCodingCompetitionsProblemParser.ts
+++ b/src/parsers/problem/GoogleCodingCompetitionsProblemParser.ts
@@ -16,7 +16,7 @@ export class GoogleCodingCompetitionsProblemParser extends Parser {
     const elem = htmlToElement(html);
     const task = new TaskBuilder('Google Coding Competitions').setUrl(url);
 
-    task.setName(elem.querySelector('#problem-select-selected-text').textContent.split(' (')[0]);
+    task.setName(elem.querySelector('title').textContent.split(' - ')[0].trim());
     task.setCategory(elem.querySelector('.competition-nav p.headline-5').textContent);
 
     const container = elem.querySelector('.problem-description');

--- a/src/parsers/problem/GoogleCodingCompetitionsProblemParser.ts
+++ b/src/parsers/problem/GoogleCodingCompetitionsProblemParser.ts
@@ -29,9 +29,9 @@ export class GoogleCodingCompetitionsProblemParser extends Parser {
     task.setInteractive(interactiveText || interactiveHeader);
 
     const blocks = container.querySelectorAll('.problem-io-wrapper pre.io-content');
-    if (blocks.length !== 0) {
-      const input = blocks[0].textContent.trim();
-      const output = blocks[1].textContent.trim();
+    for (let i = 0; i < blocks.length; i += 2) {
+      const input = blocks[i].textContent.trim();
+      const output = blocks[i + 1].textContent.trim();
 
       task.addTest(input, output);
     }

--- a/tests/data/google-coding-competitions/problem/codejam.json
+++ b/tests/data/google-coding-competitions/problem/codejam.json
@@ -1,5 +1,5 @@
 {
-  "url": "https://codingcompetitions.withgoogle.com/codejam/round/0000000000007766",
+  "url": "https://codingcompetitions.withgoogle.com/codejam/round/0000000000007766/000000000004dbbd",
   "parser": "problem/GoogleCodingCompetitionsProblemParser",
   "before": "beforeGoogleCodingCompetitions",
   "result": {

--- a/tests/data/google-coding-competitions/problem/kickstart.json
+++ b/tests/data/google-coding-competitions/problem/kickstart.json
@@ -1,5 +1,5 @@
 {
-  "url": "https://codingcompetitions.withgoogle.com/kickstart/round/0000000000050ee2",
+  "url": "https://codingcompetitions.withgoogle.com/kickstart/round/0000000000050ee2/0000000000051136",
   "parser": "problem/GoogleCodingCompetitionsProblemParser",
   "before": "beforeGoogleCodingCompetitions",
   "result": {

--- a/tests/data/google-coding-competitions/problem/multiple-samples.json
+++ b/tests/data/google-coding-competitions/problem/multiple-samples.json
@@ -1,0 +1,36 @@
+{
+  "url": "https://codingcompetitions.withgoogle.com/kickstart/round/000000000019ffc7/00000000001d3f5b",
+  "parser": "problem/GoogleCodingCompetitionsProblemParser",
+  "before": "beforeGoogleCodingCompetitions",
+  "result": {
+    "name": "Workout",
+    "group": "Google Coding Competitions - Round A 2020 - Kick Start 2020",
+    "url": "https://codingcompetitions.withgoogle.com/kickstart/round/000000000019ffc7/00000000001d3f5b",
+    "interactive": false,
+    "memoryLimit": 1024,
+    "timeLimit": 20000,
+    "tests": [
+      {
+        "input": "1\n3 1\n100 200 230\n",
+        "output": "Case #1: 50\n"
+      },
+      {
+        "input": "3\n5 2\n10 13 15 16 17\n5 6\n9 10 20 26 30\n8 3\n1 2 3 4 5 6 7 10\n",
+        "output": "Case #1: 2\nCase #2: 3\nCase #3: 1\n"
+      }
+    ],
+    "testType": "multiNumber",
+    "input": {
+      "type": "stdin"
+    },
+    "output": {
+      "type": "stdout"
+    },
+    "languages": {
+      "java": {
+        "mainClass": "Solution",
+        "taskClass": "Workout"
+      }
+    }
+  }
+}

--- a/tests/parser-functions.ts
+++ b/tests/parser-functions.ts
@@ -40,9 +40,7 @@ export default {
   },
 
   async beforeGoogleCodingCompetitions(page: Page): Promise<void> {
-    await page.waitFor('.problems-nav-problem-btn');
-    await page.click('.problems-nav-problem-btn');
-    await page.waitFor('.problem-description');
+    await page.waitFor('.problem-io-wrapper pre.io-content');
   },
 
   async beforeOldGoogleCodeJam(page: Page): Promise<void> {


### PR DESCRIPTION
The current parser parses the first block of io only, but some problems have more than one block.