### PR TITLE
Fix parsing memory limit in some acmsguru problems in the Codeforces parser

### DIFF
--- a/src/parsers/problem/CodeforcesProblemParser.ts
+++ b/src/parsers/problem/CodeforcesProblemParser.ts
@@ -114,7 +114,7 @@ export class CodeforcesProblemParser extends Parser {
     task.setCategory('acm.sgu.ru archive');
 
     task.setTimeLimit(parseFloat(/time limit per test: ([0-9.]+)\s+sec/.exec(html)[1]) * 1000);
-    task.setMemoryLimit(Math.floor(parseInt(/memory limit per test:\s+(\d+)\s+KB/.exec(html)[1], 10) / 1000));
+    task.setMemoryLimit(Math.floor(parseInt(/memory\s+limit per test:\s+(\d+)\s+KB/.exec(html)[1], 10) / 1000));
 
     const blocks = elem.querySelectorAll('font > pre');
     for (let i = 0; i < blocks.length; i += 2) {

--- a/tests/data/codeforces/problem/acm-sgu-ru-inside-table.json
+++ b/tests/data/codeforces/problem/acm-sgu-ru-inside-table.json
@@ -1,17 +1,17 @@
 {
-  "url": "https://codeforces.com/problemsets/acmsguru/problem/99999/100?locale=en",
+  "url": "https://codeforces.com/problemsets/acmsguru/problem/99999/123?locale=en",
   "parser": "problem/CodeforcesProblemParser",
   "result": {
-    "name": "100. A+B",
+    "name": "123. The sum",
     "group": "Codeforces - acm.sgu.ru archive",
-    "url": "https://codeforces.com/problemsets/acmsguru/problem/99999/100?locale=en",
+    "url": "https://codeforces.com/problemsets/acmsguru/problem/99999/123?locale=en",
     "interactive": false,
-    "memoryLimit": 65,
+    "memoryLimit": 4,
     "timeLimit": 250,
     "tests": [
       {
-        "input": "5 3\n",
-        "output": "8\n"
+        "input": "5\n",
+        "output": "12\n"
       }
     ],
     "testType": "single",
@@ -24,7 +24,7 @@
     "languages": {
       "java": {
         "mainClass": "Main",
-        "taskClass": "AB"
+        "taskClass": "TheSum"
       }
     }
   }


### PR DESCRIPTION
For example, this problem was unparseable: https://codeforces.com/problemsets/acmsguru/problem/99999/123?locale=en