### PR TITLE
Add support for one more yandex contest link type

### DIFF
--- a/src/parsers/problem/YandexProblemParser.ts
+++ b/src/parsers/problem/YandexProblemParser.ts
@@ -5,12 +5,13 @@ import { Parser } from '../Parser';
 
 export class YandexProblemParser extends Parser {
   public getMatchPatterns(): string[] {
-    return [
-      'https://*.contest.yandex.com/*/contest/*/problems/*/',
-      'https://*.contest2.yandex.com/*/contest/*/problems/*/',
-      'https://*.contest.yandex.ru/*/contest/*/problems/*/',
-      'https://*.contest2.yandex.ru/*/contest/*/problems/*/',
-    ];
+    const patterns: string[] = ['https://*.contest.yandex.com/*/contest/*/problems/*/'];
+
+    patterns.push(...patterns.map(pattern => pattern.replace('.com', '.ru')));
+    patterns.push(...patterns.map(pattern => pattern.replace('/*/contest', '/contest')));
+    patterns.push(...patterns.map(pattern => pattern.replace('contest.yandex', 'contest2.yandex')));
+
+    return patterns;
   }
 
   public async parse(url: string, html: string): Promise<Sendable> {


### PR DESCRIPTION
Some contests look like 'https://official.contest.yandex.ru/contest/18275/problems/E/'. They have 'yandex.ru/contest', but not 'yandex.ru/*/contest'.

I decided to change patterns building so that I won't add 4 more lines just to add this change.