### PR TITLE
Bugfix: DMOJ parser gives empty name when parsing problems that have already been attempted (submitted to).

### DIFF
--- a/src/parsers/problem/DMOJProblemParser.ts
+++ b/src/parsers/problem/DMOJProblemParser.ts
@@ -12,7 +12,7 @@ export class DMOJProblemParser extends Parser {
     const elem = htmlToElement(html);
     const task = new TaskBuilder('DMOJ').setUrl(url);
 
-    task.setName(elem.querySelector('.problem-title').childNodes[1].textContent);
+    task.setName(elem.querySelector('.problem-title h2').textContent);
 
     const inputs = [...elem.querySelectorAll('h4')].filter(el => {
       const text = el.textContent.toLowerCase();


### PR DESCRIPTION
Steps to replicate original bug:

1. Log into your DMOJ account
2. Pick a problem you've already submitted to
3. Use Competitive Companion to fetch that problem

The fetched info will have an empty problem name.  Not really sure how to add this to unit tests since you have to be logged in, maybe something involving DMOJ API tokens could work.

To fix the issue, I just slightly changed the selector used for finding the problem name.