### PR TITLE
Fix AtCoder problem parser bug arising from recent changes to the problem page

### DIFF
--- a/src/parsers/problem/AtCoderProblemParser.ts
+++ b/src/parsers/problem/AtCoderProblemParser.ts
@@ -12,7 +12,11 @@ export class AtCoderProblemParser extends Parser {
     const elem = htmlToElement(html);
     const task = new TaskBuilder('AtCoder').setUrl(url);
 
-    task.setName(elem.querySelector('h2, .h2').textContent);
+    // Document preprocessing to remove the "editorial" button inside the heading
+    const h2 = elem.querySelector('h2, .h2');
+    h2.removeChild(elem.querySelector('.h2 > .btn'));
+
+    task.setName(h2.textContent.replace(/\n/g, '').replace(/\t/g, ''));
     task.setCategory(elem.querySelector('.contest-name, .contest-title').textContent);
 
     const interactiveSentences = ['This is an interactive task', 'This is a reactive problem'];


### PR DESCRIPTION
Recently AtCoder changed how they display the editorials. The button was moved inside the heading, causing the parser to load the problem name incorrectly. (Run tests on the previous version to verify this.) 
The pull request updates the parser to correctly load the problem name.