### PR TITLE
Fix CSES parser to exclude code blocks in statement

### DIFF
--- a/src/parsers/problem/CSESProblemParser.ts
+++ b/src/parsers/problem/CSESProblemParser.ts
@@ -19,7 +19,25 @@ export class CSESProblemParser extends Parser {
     task.setTimeLimit(parseFloat(/([0-9.]+) s/.exec(limitsStr)[1]) * 1000);
     task.setMemoryLimit(parseInt(/(\d+) MB/.exec(limitsStr)[1], 10));
 
-    const codeBlocks = elem.querySelectorAll('.content > code');
+    // Grabs the first two code blocks after each "example" header, to avoid
+    // matching code blocks in the problem statement or explanations.
+    const find = function (nodes: Element[]): Element[] {
+      let count = 0;
+      const result: Element[] = [];
+      for (let i = 0; i < nodes.length; i++) {
+        if (nodes[i].id.startsWith('example')) {
+          count = 2;
+          continue;
+        }
+        if (count > 0) {
+          result.push(nodes[i]);
+          count--;
+        }
+      }
+      return result;
+    };
+
+    const codeBlocks = find([...elem.querySelectorAll('[id^=example], .content > code')]);
     for (let i = 0; i < codeBlocks.length - 1; i += 2) {
       const input = codeBlocks[i].textContent.trim();
       const output = codeBlocks[i + 1].textContent.trim();

--- a/tests/data/cses/problem/code_blocks_in_statement.json
+++ b/tests/data/cses/problem/code_blocks_in_statement.json
@@ -1,0 +1,31 @@
+{
+  "url": "https://cses.fi/problemset/task/1729",
+  "parser": "problem/CSESProblemParser",
+  "result": {
+    "name": "Stick Game",
+    "group": "CSES - CSES Problem Set",
+    "url": "https://cses.fi/problemset/task/1729",
+    "interactive": false,
+    "memoryLimit": 512,
+    "timeLimit": 1000,
+    "tests": [
+      {
+        "input": "10 3\n1 3 4\n",
+        "output": "WLWWWWLWLW\n"
+      }
+    ],
+    "testType": "single",
+    "input": {
+      "type": "stdin"
+    },
+    "output": {
+      "type": "stdout"
+    },
+    "languages": {
+      "java": {
+        "mainClass": "Main",
+        "taskClass": "StickGame"
+      }
+    }
+  }
+}


### PR DESCRIPTION
The parser previously matched any code as sample input/output, including
when there were code blocks as part of the output specification or
problem statement (example: https://cses.fi/problemset/task/1729).

Fixed this by only matching the first two code blocks after each
"example" header (and added a test).