### PR TITLE
add back previous version library checker parser for old.yosupo.jp

### DIFF
--- a/src/parsers/parsers.ts
+++ b/src/parsers/parsers.ts
@@ -63,6 +63,7 @@ import { LuoguProblemParser } from './problem/LuoguProblemParser';
 import { MrJudgeProblemParser } from './problem/MrJudgeProblemParser';
 import { MSKInformaticsProblemParser } from './problem/MSKInformaticsProblemParser';
 import { NowCoderProblemParser } from './problem/NowCoderProblemParser';
+import { OldLibraryCheckerProblemParser } from './problem/OldLibraryCheckerProblemParser';
 import { OmegaUpProblemParser } from './problem/OmegaUpProblemParser';
 import { PandaOnlineJudgeProblemParser } from './problem/PandaOnlineJudgeProblemParser';
 import { PEGJudgeProblemParser } from './problem/PEGJudgeProblemParser';
@@ -162,6 +163,7 @@ export const parsers: Parser[] = [
   new KattisContestParser(),
 
   new LibraryCheckerProblemParser(),
+  new OldLibraryCheckerProblemParser(),
 
   new LibreOJProblemParser(),
   new LibreOJContestParser(),

--- a/src/parsers/problem/OldLibraryCheckerProblemParser.ts
+++ b/src/parsers/problem/OldLibraryCheckerProblemParser.ts
@@ -1,0 +1,30 @@
+import { Sendable } from '../../models/Sendable';
+import { TaskBuilder } from '../../models/TaskBuilder';
+import { htmlToElement } from '../../utils/dom';
+import { Parser } from '../Parser';
+
+export class OldLibraryCheckerProblemParser extends Parser {
+  public getMatchPatterns(): string[] {
+    return ['https://old.yosupo.jp/problem/*'];
+  }
+
+  public async parse(url: string, html: string): Promise<Sendable> {
+    const elem = htmlToElement(html);
+    const task = new TaskBuilder('Library Checker').setUrl(url);
+
+    task.setName(elem.querySelector('.uk-container > h1').textContent);
+
+    task.setTimeLimit(5000);
+    task.setMemoryLimit(1024);
+
+    const preBlocks = [...elem.querySelectorAll('pre')].filter(block => block.querySelector('code') === null);
+    for (let i = 0; i < preBlocks.length - 1; i += 2) {
+      const input = preBlocks[i].textContent;
+      const output = preBlocks[i + 1].textContent;
+
+      task.addTest(input, output);
+    }
+
+    return task.build();
+  }
+}


### PR DESCRIPTION
Since `old.yosupo.jp` is still alive and I prefer solving problem on it, so I'd like add back the previous version parser for it with a new name `OldLibraryCheckProblemParser`.

Thanks for your review whatever!