### PR TITLE
Fix the CodeDrills parser

### DIFF
--- a/src/parsers/problem/CodeDrillsProblemParser.ts
+++ b/src/parsers/problem/CodeDrillsProblemParser.ts
@@ -12,7 +12,7 @@ export class CodeDrillsProblemParser extends Parser {
     const elem = htmlToElement(html);
     const task = new TaskBuilder('CodeDrills').setUrl(url);
 
-    task.setName(elem.querySelector('main .display-1').textContent.trim());
+    task.setName(elem.querySelector('.v-main').textContent.trim());
 
     const breadcrumbs = elem.querySelectorAll('main .v-breadcrumbs > li');
     if (breadcrumbs.length >= 3) {


### PR DESCRIPTION
Found this broken today. It was working fine until last week.
Tested on https://codedrills.io/contests/icpc-amritapuri-2020-preliminary-round/problems/break-merge-and-sort and https://codedrills.io/contests/amrita-icpc-practice-session-6/problems/sort-the-array

I tested for sample test cases. 
Java class name and problem name is too long.
