### PR TITLE
Support custom session in Kattis

### DIFF
--- a/src/parsers/problem/KattisProblemParser.ts
+++ b/src/parsers/problem/KattisProblemParser.ts
@@ -5,7 +5,11 @@ import { Parser } from '../Parser';
 
 export class KattisProblemParser extends Parser {
   public getMatchPatterns(): string[] {
-    return ['https://*.kattis.com/problems/*', 'https://*.kattis.com/contests/*/problems/*'];
+    return [
+      'https://*.kattis.com/problems/*',
+      'https://*.kattis.com/contests/*/problems/*',
+      'https://*.kattis.com/sessions/*/problems/*',
+    ];
   }
 
   public async parse(url: string, html: string): Promise<Sendable> {


### PR DESCRIPTION
This is a possible pattern for Kattis URL too.

Example URL format: https://abc.kattis.com/sessions/ab12cd/problems/problemname (not real URL)

