### PR TITLE
Add HDOJ NG Parser

### DIFF
--- a/src/parsers/contest/HDOJNGContestParser.ts
+++ b/src/parsers/contest/HDOJNGContestParser.ts
@@ -1,0 +1,11 @@
+import { HDOJNGProblemParser } from '../problem/HDOJNGProblemParser';
+import { SimpleContestParser } from '../SimpleContestParser';
+
+export class HDOJNGContestParser extends SimpleContestParser {
+  protected linkSelector = '.page-card-table > tbody > tr > td:nth-child(3) > a';
+  protected problemParser = new HDOJNGProblemParser();
+
+  public getMatchPatterns(): string[] {
+    return ['https://acm.hdu.edu.cn/contest/problems\\?*'];
+  }
+}

--- a/src/parsers/parsers.ts
+++ b/src/parsers/parsers.ts
@@ -17,6 +17,7 @@ import { FZUOnlineJudgeContestParser } from './contest/FZUOnlineJudgeContestPars
 import { HackerEarthContestParser } from './contest/HackerEarthContestParser';
 import { HackerRankContestParser } from './contest/HackerRankContestParser';
 import { HDOJContestParser } from './contest/HDOJContestParser';
+import { HDOJNGContestParser } from './contest/HDOJNGContestParser';
 import { HihoCoderContestParser } from './contest/HihoCoderContestParser';
 import { HydroContestParser } from './contest/HydroContestParser';
 import { KattisContestParser } from './contest/KattisContestParser';
@@ -61,6 +62,7 @@ import { GoogleCodingCompetitionsProblemParser } from './problem/GoogleCodingCom
 import { HackerEarthCodeArenaParser } from './problem/HackerEarthCodeArenaParser';
 import { HackerEarthProblemParser } from './problem/HackerEarthProblemParser';
 import { HackerRankProblemParser } from './problem/HackerRankProblemParser';
+import { HDOJNGProblemParser } from './problem/HDOJNGProblemParser';
 import { HDOJProblemParser } from './problem/HDOJProblemParser';
 import { HihoCoderProblemParser } from './problem/HihoCoderProblemParser';
 import { HITOnlineJudgeProblemParser } from './problem/HITOnlineJudgeProblemParser';
@@ -176,6 +178,9 @@ export const parsers: Parser[] = [
 
   new HDOJProblemParser(),
   new HDOJContestParser(),
+
+  new HDOJNGProblemParser(),
+  new HDOJNGContestParser(),
 
   new HITOnlineJudgeProblemParser(),
 

--- a/src/parsers/problem/HDOJNGProblemParser.ts
+++ b/src/parsers/problem/HDOJNGProblemParser.ts
@@ -1,0 +1,35 @@
+import { Sendable } from '../../models/Sendable';
+import { TaskBuilder } from '../../models/TaskBuilder';
+import { htmlToElement } from '../../utils/dom';
+import { Parser } from '../Parser';
+
+export class HDOJNGProblemParser extends Parser {
+  public getMatchPatterns(): string[] {
+    return ['https://acm.hdu.edu.cn/contest/problem\\?*'];
+  }
+
+  public async parse(url: string, html: string): Promise<Sendable> {
+    const elem = htmlToElement(html);
+    const task = new TaskBuilder('HDOJNG').setUrl(url);
+
+    const sidebar = elem.querySelector('.problem-sidebar');
+
+    task.setName(sidebar.querySelector('h3').textContent);
+
+    const limits = sidebar.querySelectorAll('.info-value');
+
+    const timeLimitStr = limits[0].textContent.split('/')[1];
+    const memoryLimitStr = limits[1].textContent.split('/')[1];
+
+    task.setTimeLimit(parseInt(/(\d+)/.exec(timeLimitStr)[1], 10));
+    task.setMemoryLimit(parseInt(/(\d+)/.exec(memoryLimitStr)[1], 10));
+
+    const blocks = elem.querySelectorAll('.problem-detail-block > .code-block');
+
+    for (let i = 0; i < blocks.length - 1; i += 2) {
+      task.addTest(blocks[i].textContent, blocks[i + 1].textContent);
+    }
+
+    return task.build();
+  }
+}


### PR DESCRIPTION
HDUOJ has updated new UI in the recent contests, the original parser is not available with the new UI. It can be distinguished simply by the URL prefix.

The new UI currently is only used in the recent contests, problem archive is still using the old UI.