### PR TITLE
Add BOJ Stack parsing in BaekjoonOnlineJudgeProblemParser

### DIFF
--- a/src/parsers/problem/BaekjoonOnlineJudgeProblemParser.ts
+++ b/src/parsers/problem/BaekjoonOnlineJudgeProblemParser.ts
@@ -5,7 +5,10 @@ import { Parser } from '../Parser';
 
 export class BaekjoonOnlineJudgeProblemParser extends Parser {
   public getMatchPatterns(): string[] {
-    return ['https://www.acmicpc.net/problem/*'];
+    return [
+      'https://www.acmicpc.net/problem/*',
+      'https://stack.acmicpc.net/problem/preview/*',
+    ];
   }
 
   public async parse(url: string, html: string): Promise<Sendable> {

--- a/src/parsers/problem/BaekjoonOnlineJudgeProblemParser.ts
+++ b/src/parsers/problem/BaekjoonOnlineJudgeProblemParser.ts
@@ -5,10 +5,7 @@ import { Parser } from '../Parser';
 
 export class BaekjoonOnlineJudgeProblemParser extends Parser {
   public getMatchPatterns(): string[] {
-    return [
-      'https://www.acmicpc.net/problem/*',
-      'https://stack.acmicpc.net/problem/preview/*',
-    ];
+    return ['https://www.acmicpc.net/problem/*', 'https://stack.acmicpc.net/problem/preview/*'];
   }
 
   public async parse(url: string, html: string): Promise<Sendable> {


### PR DESCRIPTION
[BOJ Stack](https://stack.acmicpc.net/) is a site used to upload problems to [BOJ](https://www.acmicpc.net/).

It provides a preview feature when editing problems, and this preview page can be parsed with BaekjoonOnlineJudgeProblemParser. 

So, I think it would be helpful to add the BOJ stack to this parser.
