### PR TITLE
Fix TLX Parser

### DIFF
--- a/src/parsers/problem/TLXProblemParser.ts
+++ b/src/parsers/problem/TLXProblemParser.ts
@@ -35,8 +35,8 @@ export class TLXProblemParser extends Parser {
 
     const limitNodes = elem.querySelector('.programming-problem-statement__limits');
 
-    const timeLimitStr = limitNodes.textContent;
-    task.setTimeLimit(parseFloat(/([0-9.]+) ?s/.exec(timeLimitStr)[1]) * 1000);
+    const [, timeLimit, timeLimitUnit] = /([0-9.]+) ?(s|ms)/.exec(limitNodes.textContent);
+    task.setTimeLimit(timeLimitUnit === 's' ? parseFloat(timeLimit) * 1000 : parseFloat(timeLimit));
 
     const memoryLimitStr = limitNodes.textContent;
     task.setMemoryLimit(parseInt(/(\d+) ?MB/.exec(memoryLimitStr)[1], 10));
@@ -66,8 +66,10 @@ export class TLXProblemParser extends Parser {
           return el.nextElementSibling;
         } else if (el.children.length >= 3) {
           return el.children[2];
-        } else {
+        } else if (el.children.length >= 1) {
           return el.children[0];
+        } else {
+          return {textContent: ''};
         }
       });
 

--- a/src/parsers/problem/TLXProblemParser.ts
+++ b/src/parsers/problem/TLXProblemParser.ts
@@ -24,7 +24,8 @@ export class TLXProblemParser extends Parser {
       .trim();
     task.setName(name);
 
-    const categorySelector = '.single-problemset-problem-routes__title--link, .single-contest-routes__header > h2, .single-course-chapter-routes';
+    const categorySelector =
+      '.single-problemset-problem-routes__title--link, .single-contest-routes__header > h2, .single-course-chapter-routes';
     task.setCategory(elem.querySelector(categorySelector).textContent);
 
     // Problems in the problemset don't include the letter in the title, so we add it here
@@ -69,7 +70,7 @@ export class TLXProblemParser extends Parser {
         } else if (el.children.length >= 1) {
           return el.children[0];
         } else {
-          return {textContent: ''};
+          return { textContent: '' };
         }
       });
 

--- a/src/parsers/problem/TLXProblemParser.ts
+++ b/src/parsers/problem/TLXProblemParser.ts
@@ -25,7 +25,7 @@ export class TLXProblemParser extends Parser {
     task.setName(name);
 
     const categorySelector =
-      '.single-problemset-problem-routes__title--link, .single-contest-routes__header > h2, .single-course-chapter-routes';
+      '.single-problemset-problem-routes__title--link, .single-contest-routes__header > h2, .course-chapters-sidebar__chapters h4';
     task.setCategory(elem.querySelector(categorySelector).textContent);
 
     // Problems in the problemset don't include the letter in the title, so we add it here

--- a/src/parsers/problem/TLXProblemParser.ts
+++ b/src/parsers/problem/TLXProblemParser.ts
@@ -5,7 +5,12 @@ import { Parser } from '../Parser';
 
 export class TLXProblemParser extends Parser {
   public getMatchPatterns(): string[] {
-    return ['https://tlx.toki.id/contests/*/problems/*', 'https://tlx.toki.id/problems/*/*'];
+    return [
+      'https://tlx.toki.id/contests/*/problems/*',
+      'https://tlx.toki.id/problems/*/*',
+      'https://tlx.toki.id/courses/basic/chapters/*/problems/*',
+      'https://tlx.toki.id/courses/competitive/chapters/*/problems/*',
+    ];
   }
 
   public async parse(url: string, html: string): Promise<Sendable> {
@@ -19,7 +24,7 @@ export class TLXProblemParser extends Parser {
       .trim();
     task.setName(name);
 
-    const categorySelector = '.single-problemset-problem-routes__title--link, .single-contest-routes__header > h2';
+    const categorySelector = '.single-problemset-problem-routes__title--link, .single-contest-routes__header > h2, .single-course-chapter-routes';
     task.setCategory(elem.querySelector(categorySelector).textContent);
 
     // Problems in the problemset don't include the letter in the title, so we add it here


### PR DESCRIPTION
I noticed that the parser does not work with problems accessed through the available courses ([example](https://tlx.toki.id/courses/competitive/chapters/06/problems/C)), so I added the URL patterns and updated the title parser which seems to be the only difference with regular problems. I also fixed an error when the problem uses millisecond as the unit of the time limit, which would not work with the current regex pattern ([example](https://tlx.toki.id/problems/tsoc-april-fools-2021/A)). The output parser also now returns an empty string `""` if the element containing the output example cannot be found ([example](https://tlx.toki.id/courses/basic/chapters/05/problems/B)).