### PR TITLE
Added DOMjudge Contest Parser (+ JSZip)

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,6 +253,7 @@ Third-party libraries that can be found in the minified extension:
 - [snarkdown 2.0.0](https://github.com/developit/snarkdown/blob/2.0.0/src/index.js)
 - [webextension-polyfill 0.10.0](https://github.com/mozilla/webextension-polyfill/blob/0.10.0/src/browser-polyfill.js)
 - [pdfjs-dist 3.11.174](https://cdn.jsdelivr.net/npm/pdfjs-dist@3.11.174/build/pdf.js)
+- [jszip 3.10.1](https://github.com/Stuk/jszip/blob/v3.10.1/dist/jszip.js)
 - [cyrillic-to-translit-js 3.2.1](https://github.com/greybax/cyrillic-to-translit-js/blob/05f02e9e1df6d338f35258443f2e9c910bd8ccd4/CyrillicToTranslit.js)
 
 Package the extension by `cd`'ing into the source code submission directory, installing the dependencies with `pnpm install` and packaging with `pnpm package`. The result can be found in the `dist/` directory.

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
   },
   "dependencies": {
     "cyrillic-to-translit-js": "3.2.1",
+    "jszip": "3.10.1",
     "nanobar": "0.4.2",
     "pdfjs-dist": "3.11.174",
     "snarkdown": "2.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ dependencies:
   cyrillic-to-translit-js:
     specifier: 3.2.1
     version: 3.2.1
+  jszip:
+    specifier: 3.10.1
+    version: 3.10.1
   nanobar:
     specifier: 0.4.2
     version: 0.4.2
@@ -2815,7 +2818,6 @@ packages:
 
   /core-util-is@1.0.3:
     resolution: {integrity: sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==}
-    dev: true
 
   /cosmiconfig@8.3.6(typescript@5.3.3):
     resolution: {integrity: sha512-kcZ6+W5QzcJ3P1Mt+83OUv/oHFqZHIx8DuxG6eZ5RGMERoLqp4BuGjhHLYGK+Kf5XVkQvqBSmAy/nGWN3qDgEA==}
@@ -4413,7 +4415,6 @@ packages:
 
   /immediate@3.0.6:
     resolution: {integrity: sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==}
-    dev: true
 
   /import-fresh@3.3.0:
     resolution: {integrity: sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==}
@@ -4709,7 +4710,6 @@ packages:
 
   /isarray@1.0.0:
     resolution: {integrity: sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==}
-    dev: true
 
   /isarray@2.0.5:
     resolution: {integrity: sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==}
@@ -5356,7 +5356,6 @@ packages:
       pako: 1.0.11
       readable-stream: 2.3.8
       setimmediate: 1.0.5
-    dev: true
 
   /jwa@1.4.1:
     resolution: {integrity: sha512-qiLX/xhEEFKUAJ6FiBMbes3w9ATzyk5W7Hvzpa/SLYdxNtng+gcurvrI7TbACjIXlsJyr05/S1oUhZrc63evQA==}
@@ -5420,7 +5419,6 @@ packages:
     resolution: {integrity: sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==}
     dependencies:
       immediate: 3.0.6
-    dev: true
 
   /lighthouse-logger@1.4.2:
     resolution: {integrity: sha512-gPWxznF6TKmUHrOQjlVo2UbaL2EJ71mb2CCeRs/2qBpi4L/g4LUVc9+3lKQ6DTUZwJswfM7ainGrLO1+fOqa2g==}
@@ -6062,7 +6060,6 @@ packages:
 
   /pako@1.0.11:
     resolution: {integrity: sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==}
-    dev: true
 
   /parent-module@1.0.1:
     resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
@@ -6241,7 +6238,6 @@ packages:
 
   /process-nextick-args@2.0.1:
     resolution: {integrity: sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==}
-    dev: true
 
   /process-warning@2.3.2:
     resolution: {integrity: sha512-n9wh8tvBe5sFmsqlg+XQhaQLumwpqoAUruLwjCopgTmUBjJ/fjtBsJzKleCaIGBOMXYEhp1YfKl4d7rJ5ZKJGA==}
@@ -6420,7 +6416,6 @@ packages:
       safe-buffer: 5.1.2
       string_decoder: 1.1.1
       util-deprecate: 1.0.2
-    dev: true
 
   /readable-stream@3.6.2:
     resolution: {integrity: sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==}
@@ -6648,7 +6643,6 @@ packages:
 
   /safe-buffer@5.1.2:
     resolution: {integrity: sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==}
-    dev: true
 
   /safe-buffer@5.2.1:
     resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
@@ -6759,7 +6753,6 @@ packages:
 
   /setimmediate@1.0.5:
     resolution: {integrity: sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==}
-    dev: true
 
   /sha.js@2.4.11:
     resolution: {integrity: sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==}
@@ -7060,7 +7053,6 @@ packages:
     resolution: {integrity: sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==}
     dependencies:
       safe-buffer: 5.1.2
-    dev: true
 
   /string_decoder@1.3.0:
     resolution: {integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==}

--- a/src/parsers/contest/DOMjudgeContestParser.ts
+++ b/src/parsers/contest/DOMjudgeContestParser.ts
@@ -1,0 +1,109 @@
+import JSZip from 'jszip';
+import { Task } from '../../models/Task';
+import { TaskBuilder } from '../../models/TaskBuilder';
+import { ContestParser } from '../ContestParser';
+
+export class DOMjudgeContestParser extends ContestParser<HTMLDivElement> {
+  public getMatchPatterns(): string[] {
+    // Not perfect, but this should work for all DOMjudge instances in general
+    return ['*://*/team/problems', '*://*/public/problems'];
+  }
+
+  public canHandlePage(): boolean {
+    // Determines if page is handled based on existence of "DOMjudge" text
+    const head = document.querySelector('nav.navbar a.navbar-brand');
+    return head !== null && head.textContent.includes('DOMjudge');
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  protected async getTasksToParse(html: string, _url: string): Promise<HTMLDivElement[]> {
+    const parser = new DOMParser();
+    const doc = parser.parseFromString(html, 'text/html');
+    const taskElements = Array.from(doc.querySelectorAll('.card-body'));
+
+    return taskElements as HTMLDivElement[];
+  }
+
+  protected async parseTask(taskElement: HTMLDivElement): Promise<Task> {
+    // This parsing is a little difficult because it should work for DOMjudge 7 and DOMjudge 8 instances.
+    let title = taskElement.querySelector('.card-title, h2.card-title')?.textContent?.trim();
+    title = title.replace('Problem', '').trim();
+
+    const subtitle = taskElement.querySelector('.card-subtitle, h3.card-subtitle')?.textContent?.trim();
+
+    const limitsText = taskElement.querySelector('h5.card-subtitle, h4.card-subtitle')?.textContent?.trim();
+    const [timeLimit, memoryLimit] = this.parseLimits(limitsText);
+
+    const problemText = taskElement.querySelector('a[href$="/text"]')?.getAttribute('href');
+    let zipUrl = taskElement.querySelector('a[href$=".zip"]')?.getAttribute('href');
+
+    const taskBuilder = new TaskBuilder('DOMjudge');
+    taskBuilder.setName(subtitle ? `${title}: ${subtitle}` : title);
+    taskBuilder.setTimeLimit(timeLimit);
+    taskBuilder.setMemoryLimit(memoryLimit);
+    taskBuilder.interactive = taskElement.textContent.includes('testing');
+
+    if (problemText) {
+      const fullUrl = new URL(problemText, window.location.origin);
+      taskBuilder.setUrl(fullUrl.toString());
+    }
+
+    if (zipUrl) {
+      const fullUrl = new URL(zipUrl, window.location.origin);
+      zipUrl = fullUrl.toString();
+    }
+
+    if (zipUrl) {
+      const testCases = await this.fetchTestCases(zipUrl);
+      testCases.forEach(testCase => taskBuilder.addTest(testCase.input, testCase.output, false));
+    }
+
+    return taskBuilder.build();
+  }
+
+  private async fetchTestCases(zipUrl: string): Promise<{ input: string; output: string }[]> {
+    try {
+      const response = await fetch(zipUrl);
+      if (!response.ok) throw new Error(`Failed to download ZIP file from ${zipUrl}`);
+
+      const arrayBuffer = await response.arrayBuffer();
+      const zip = new JSZip();
+      const content = await zip.loadAsync(arrayBuffer);
+
+      const testCases: Record<string, { input: string; output: string }> = {};
+
+      for (const fileName in content.files) {
+        if (Object.prototype.hasOwnProperty.call(content.files, fileName)) {
+          if (fileName.endsWith('.in') || fileName.endsWith('.out') || fileName.endsWith('.ans')) {
+            const fileContent = await content.files[fileName].async('string');
+            const fileNumber = fileName.match(/(\d+[a-zA-Z]*)/)?.[0];
+
+            if (fileNumber) {
+              testCases[fileNumber] = testCases[fileNumber] || { input: '', output: '' };
+              const fileType = fileName.endsWith('.in') ? 'input' : 'output';
+              testCases[fileNumber][fileType] = fileContent;
+            }
+          }
+        }
+      }
+
+      return Object.values(testCases);
+    } catch (error) {
+      console.error(`Error extracting test cases from ZIP: ${error}`);
+      return [];
+    }
+  }
+
+  private parseLimits(limitsText: string | null): [number, number] {
+    const defaultTime = 1000; // Default time in milliseconds
+    const defaultMemory = 2048; // Default memory in MB
+
+    const timeMatch = limitsText?.match(/(\d+\.?\d*)\s*seconds?/);
+    const memoryMatch = limitsText?.match(/(\d+)\s*(MB|GB)/);
+
+    const time = timeMatch ? parseFloat(timeMatch[1]) * 1000 : defaultTime;
+    const memory = memoryMatch ? parseInt(memoryMatch[1]) * (memoryMatch[2] === 'GB' ? 1024 : 1) : defaultMemory;
+
+    return [time, memory];
+  }
+}

--- a/src/parsers/contest/DOMjudgeContestParser.ts
+++ b/src/parsers/contest/DOMjudgeContestParser.ts
@@ -6,7 +6,17 @@ import { ContestParser } from '../ContestParser';
 export class DOMjudgeContestParser extends ContestParser<HTMLDivElement> {
   public getMatchPatterns(): string[] {
     // Not perfect, but this should work for all DOMjudge instances in general
-    return ['*://*/team/problems', '*://*/public/problems'];
+    const patterns = [];
+
+    for (const path of ['/team/problems', '/public/problems']) {
+      for (const prefix of ['', '/*']) {
+        for (const protocol of ['http', 'https']) {
+          patterns.push(protocol + '://*' + prefix + path);
+        }
+      }
+    }
+
+    return patterns;
   }
 
   public canHandlePage(): boolean {
@@ -89,7 +99,7 @@ export class DOMjudgeContestParser extends ContestParser<HTMLDivElement> {
 
       return Object.values(testCases);
     } catch (error) {
-      console.error(`Error extracting test cases from ZIP: ${error}`);
+      console.error('Error extracting test cases from ZIP:', error);
       return [];
     }
   }

--- a/src/parsers/parsers.ts
+++ b/src/parsers/parsers.ts
@@ -12,6 +12,7 @@ import { CPythonUZContestParser } from './contest/CPythonUZContestParser';
 import { CSESContestParser } from './contest/CSESContestParser';
 import { CSUACMOnlineJudgeContestParser } from './contest/CSUACMOnlineJudgeContestParser';
 import { DMOJContestParser } from './contest/DMOJContestParser';
+import { DOMjudgeContestParser } from './contest/DOMjudgeContestParser';
 import { ECNUOnlineJudgeContestParser } from './contest/ECNUOnlineJudgeContestParser';
 import { EolympContestParser } from './contest/EolympContestParser';
 import { FZUOnlineJudgeContestParser } from './contest/FZUOnlineJudgeContestParser';
@@ -188,6 +189,8 @@ export const parsers: Parser[] = [
 
   new DMOJProblemParser(),
   new DMOJContestParser(),
+
+  new DOMjudgeContestParser(),
 
   new ECNUOnlineJudgeProblemParser(),
   new ECNUOnlineJudgeContestParser(),


### PR DESCRIPTION
## Description
This PR introduces contest parsing for [DOMjudge](https://www.domjudge.org/), the large prominent contest control system for all ICPC contests.

<p align="center">
<img src=https://github.com/jmerle/competitive-companion/assets/12871757/06c3f826-3de3-478a-a31d-07f872909046)>
<a href=https://www.domjudge.org/demoweb/public/problems> demoweb </a>
</p>

Frankly, I was surprised that no one had mentioned it yet. Maybe because it is not a classic online judge, but a self-hosted software. Many universities use it for assignments and contests.

### Code

I wish the match pattern was better, but due to a lot of different hosts, a URL cannot be defined. I hope the `canHandlePage()` helps.

The parser itself looks at a lot of different elements, because I wanted to support the layout of DOMjudge 7 and DOMjudge 8.

Unfortunately, the sample testcases for contests and problems are not directly available. Only behind a downloadable `samples.zip`.

### JSZip

As a solution, the extension uses JSZip to fetch and parse the file contents for each problem, before passing them back to `taskBuilder`.

I understand that this is by no means perfect, and another dependency is not desirable. But this is a common system and supporting it would make sense.

I added the reference to the README.

### Tests

I tested the new parser on multiple DOMjudge installations, under Firefox and Chrome. `pnpm lint` is passing.
Recieving the problems via the [cph](https://github.com/agrawal-d/cph) VSCode extension.
Some more example judges:

- https://judge.gcpc.nwerc.eu/public/problems
- https://compro.mpi-inf.mpg.de/public/problems
- https://zerojudge.ntub.tw/public/problems
