### PR TITLE
Mendo problem parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ A browser extension which parses competitive programming problems from various o
 | LightOJ                    | ✔              |                |
 | LSYOI                      | ✔              |                |
 | Luogu                      | ✔              | ✔              |
+| Mendo                      | ✔              |                |
 | Meta Coding Competitions   | ✔              |                |
 | MOI Arena                  | ✔              | ✔              |
 | mrJudge                    | ✔              |                |

--- a/src/parsers/parsers.ts
+++ b/src/parsers/parsers.ts
@@ -89,6 +89,7 @@ import { LibreOJProblemParser } from './problem/LibreOJProblemParser';
 import { LightOJProblemParser } from './problem/LightOJProblemParser';
 import { LSYOIProblemParser } from './problem/LSYOIProblemParser';
 import { LuoguProblemParser } from './problem/LuoguProblemParser';
+import { MendoProblemParser } from './problem/MendoProblemParser';
 import { MetaCodingCompetitionsProblemParser } from './problem/MetaCodingCompetitionsProblemParser';
 import { MrJudgeProblemParser } from './problem/MrJudgeProblemParser';
 import { MSKInformaticsProblemParser } from './problem/MSKInformaticsProblemParser';
@@ -247,6 +248,8 @@ export const parsers: Parser[] = [
 
   new LuoguProblemParser(),
   new LuoguContestParser(),
+
+  new MendoProblemParser(),
 
   new MetaCodingCompetitionsProblemParser(),
 

--- a/src/parsers/problem/MendoProblemParser.ts
+++ b/src/parsers/problem/MendoProblemParser.ts
@@ -1,7 +1,7 @@
-import { Sendable } from "../../models/Sendable";
-import { TaskBuilder } from "../../models/TaskBuilder";
-import { htmlToElement } from "../../utils/dom";
-import { Parser } from "../Parser";
+import { Sendable } from '../../models/Sendable';
+import { TaskBuilder } from '../../models/TaskBuilder';
+import { htmlToElement } from '../../utils/dom';
+import { Parser } from '../Parser';
 
 export class MendoProblemParser extends Parser {
   public getMatchPatterns(): string[] {
@@ -14,41 +14,42 @@ export class MendoProblemParser extends Parser {
     const elem = htmlToElement(html);
     const task = new TaskBuilder('Mendo').setUrl(url);
 
-    task.setName(elem.querySelector(".pagetitle").textContent);
-    
+    task.setName(elem.querySelector('.pagetitle').textContent);
+
     elem.querySelectorAll('.taskContentView > h3').forEach(x => {
-      if (x.textContent.trim() == "Ограничувања") {
+      if (x.textContent.trim() == 'Ограничувања') {
         // Македонски
-        var results =
-          /Временско ограничување: (\d+) ([а-ш]+)Мемориско ограничување: (\d+) ([а-шј]+)/s
-          .exec(x.nextElementSibling.textContent);
-        var time = parseInt(results[1]), space = parseInt(results[3]);
-        if (results[2].slice(0, 6) == "секунд") time *= 1000;
+        const results = /Временско ограничување: (\d+) ([а-ш]+)Мемориско ограничување: (\d+) ([а-шј]+)/s.exec(
+          x.nextElementSibling.textContent,
+        );
+        let time = parseInt(results[1]);
+        const space = parseInt(results[3]);
+        if (results[2].slice(0, 6) == 'секунд') time *= 1000;
         // За сега нема задачи со <1MB мемориски лимит.
         task.setTimeLimit(time).setMemoryLimit(space);
       }
-      if (x.textContent.trim() == "Constraints") {
+      if (x.textContent.trim() == 'Constraints') {
         // English
-        var results =
-        /Time limit: (\d+) ([a-z]+)Memory limit: (\d+) ([a-z]+)/s
-          .exec(x.nextElementSibling.textContent);
-        var time = parseInt(results[1]), space = parseInt(results[3]);
-        if (results[2].slice(0, 6) == "second") time *= 1000;
+        const results = /Time limit: (\d+) ([a-z]+)Memory limit: (\d+) ([a-z]+)/s.exec(
+          x.nextElementSibling.textContent,
+        );
+        let time = parseInt(results[1]);
+        const space = parseInt(results[3]);
+        if (results[2].slice(0, 6) == 'second') time *= 1000;
         // As of now there aren't any problems with <1MB space limit.
         task.setTimeLimit(time).setMemoryLimit(space);
       }
     });
-    if (elem.querySelector(".taskContentView tbody")) {
-      elem.querySelector(".taskContentView tbody").childNodes.forEach(x => {
-        var parsed = /^(?:input|влез)\n(.*)(?:output|излез)\n(.*)$/s.exec(x.textContent);
-        task.addTest(parsed[1] + "\n", parsed[2] + "\n");
+    if (elem.querySelector('.taskContentView tbody')) {
+      elem.querySelector('.taskContentView tbody').childNodes.forEach(x => {
+        const parsed = /^(?:input|влез)\n(.*)(?:output|излез)\n(.*)$/s.exec(x.textContent);
+        task.addTest(parsed[1] + '\n', parsed[2] + '\n');
       });
-    }
-    else {
+    } else {
       // As of now there isn't a better discovered way of checking if it's interactive :rofl:
       task.setInteractive(true);
     }
-    task.setJavaMainClass("Main");
+    task.setJavaMainClass('Main');
     return task.build();
   }
 }

--- a/src/parsers/problem/MendoProblemParser.ts
+++ b/src/parsers/problem/MendoProblemParser.ts
@@ -1,0 +1,51 @@
+import { Sendable } from "../../models/Sendable";
+import { TaskBuilder } from "../../models/TaskBuilder";
+import { htmlToElement } from "../../utils/dom";
+import { Parser } from "../Parser";
+
+export class MendoProblemParser extends Parser {
+  public getMatchPatterns(): string[] {
+    return ['https://mendo.mk/Task.do?id=*'];
+  }
+  public async parse(url: string, html: string): Promise<Sendable> {
+    const elem = htmlToElement(html);
+    const task = new TaskBuilder('Mendo').setUrl(url);
+
+    task.setName(elem.querySelector(".pagetitle").textContent);
+    
+    elem.querySelectorAll('.taskContentView > h3').forEach(x => {
+      if (x.textContent.trim() == "Ограничувања") {
+        // Македонски
+        var results =
+          /Временско ограничување: (\d+) ([а-ш]+)\nМемориско ограничување: (\d+) ([а-шј]+)/s
+          .exec(x.nextElementSibling.textContent);
+        var time = parseInt(results[1]), space = parseInt(results[3]);
+        if (results[2].slice(0, 6) == "секунд") time *= 1000;
+        // За сега нема задачи со <1MB мемориски лимит.
+        task.setTimeLimit(time).setMemoryLimit(space);
+      }
+      if (x.textContent.trim() == "Constraints") {
+        // English
+        var results =
+        /Time limit: (\d+) ([a-z]+)Memory limit: (\d+) ([a-z]+)/s
+          .exec(x.nextElementSibling.textContent);
+        var time = parseInt(results[1]), space = parseInt(results[3]);
+        if (results[2].slice(0, 6) == "second") time *= 1000;
+        // As of now there aren't any problems with <1MB space limit.
+        task.setTimeLimit(time).setMemoryLimit(space);
+      }
+    });
+    if (elem.querySelector(".taskContentView tbody")) {
+      elem.querySelector(".taskContentView tbody").childNodes.forEach(x => {
+        var parsed = /^(?:input|влез)\n(.*)(?:output|излез)\n(.*)$/s.exec(x.textContent);
+        task.addTest(parsed[1] + "\n", parsed[2] + "\n");
+      });
+    }
+    else {
+      // As of now there isn't a better discovered way of checking if it's interactive :rofl:
+      task.setInteractive(true);
+    }
+    task.setJavaMainClass("Main");
+    return task.build();
+  }
+}

--- a/src/parsers/problem/MendoProblemParser.ts
+++ b/src/parsers/problem/MendoProblemParser.ts
@@ -7,6 +7,9 @@ export class MendoProblemParser extends Parser {
   public getMatchPatterns(): string[] {
     return ['https://mendo.mk/Task.do?id=*'];
   }
+  public getRegularExpressions(): RegExp[] {
+    return [/^https?:\/\/(?:www\.)?mendo\.mk\/Task\.do\?id=\d+$/];
+  }
   public async parse(url: string, html: string): Promise<Sendable> {
     const elem = htmlToElement(html);
     const task = new TaskBuilder('Mendo').setUrl(url);
@@ -17,7 +20,7 @@ export class MendoProblemParser extends Parser {
       if (x.textContent.trim() == "Ограничувања") {
         // Македонски
         var results =
-          /Временско ограничување: (\d+) ([а-ш]+)\nМемориско ограничување: (\d+) ([а-шј]+)/s
+          /Временско ограничување: (\d+) ([а-ш]+)Мемориско ограничување: (\d+) ([а-шј]+)/s
           .exec(x.nextElementSibling.textContent);
         var time = parseInt(results[1]), space = parseInt(results[3]);
         if (results[2].slice(0, 6) == "секунд") time *= 1000;


### PR DESCRIPTION
# About the website
[Mendo](https://mendo.mk) _(Macedonian: МЕНДО, pronounced phonetically)_ is a competitive programming website designed to teach and archive problems from Macedonian contests and others such as EJOI and JBOI. It serves as a standalone judge for its problems and accepts Pascal, C, C++ and Java as submission languages. Its servers are on the Macedonian faculty of FINKI _(ФИНКИ, abbrevation)_, in Skopje.
# Changes to Extension
Added **problem parser** for problems on Mendo. It should work with all of them, even if the HTML doesn't have a specific schema. It also somewhat distinguishes interactive problems.

Base URL for a problem is https://mendo.mk/Task.do, and it uses this regex to recognize a problem URL:
```js
/^https?:\/\/(?:www\.)?mendo\.mk\/Task\.do\?id=\d+$/
```
The catch is that some problems are only in Macedonian, some are only in English, so the code utilizes double regex recognition (essentially two blocks of the same code, wanted to make it sound crazy).

**Why are the regular expressions so strict in the code?** Changing the website's layout isn't expected to be done in near future because its layout hasn't changed since its beginning. If someone encounters bugs with the code, please let me know by mentioning me in the issue (@EntityPlantt)

## Examples
* Macedonian Problem: [Моќен Артефакт](https://mendo.mk/Task.do?id=1)
* English Problem: [Coins](https://mendo.mk/Task.do?id=190)
* Interactive Problem: [Donations](https://mendo.mk/Task.do?id=693)