### PR TITLE
Call custom hosts in parallel

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,8 +252,8 @@ To run the tests, use `pnpm test`, or `pnpm test:no-headless` to run tests with 
 The information provided below is meant for Mozilla volunteers.
 
 Software versions used:  
-Node.js: 20.13.1  
-PNPM: 9.1.1
+Node.js: 20.14.0  
+PNPM: 9.3.0
 
 Third-party libraries that can be found in the minified extension:  
 - [nanobar 0.4.2](https://github.com/jacoborus/nanobar/blob/v0.4.2/nanobar.js)
@@ -261,5 +261,6 @@ Third-party libraries that can be found in the minified extension:
 - [pdfjs-dist 4.2.67](https://cdn.jsdelivr.net/npm/pdfjs-dist@4.2.67/build/pdf.mjs)
 - [jszip 3.10.1](https://github.com/Stuk/jszip/blob/v3.10.1/dist/jszip.js)
 - [cyrillic-to-translit-js 3.2.1](https://github.com/greybax/cyrillic-to-translit-js/blob/05f02e9e1df6d338f35258443f2e9c910bd8ccd4/CyrillicToTranslit.js)
+- [p-limit 5.0.0](https://github.com/sindresorhus/p-limit/blob/v5.0.0/index.js)
 
 Package the extension by `cd`'ing into the source code submission directory, installing the dependencies with `pnpm install` and packaging with `pnpm package:firefox`. The result can be found in the `dist/` directory.

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "cyrillic-to-translit-js": "3.2.1",
     "jszip": "3.10.1",
     "nanobar": "0.4.2",
+    "p-limit": "5.0.0",
     "pdfjs-dist": "4.2.67",
     "snarkdown": "2.0.0"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,9 @@ importers:
       nanobar:
         specifier: 0.4.2
         version: 0.4.2
+      p-limit:
+        specifier: 5.0.0
+        version: 5.0.0
       pdfjs-dist:
         specifier: 4.2.67
         version: 4.2.67
@@ -2948,6 +2951,10 @@ packages:
     resolution: {integrity: sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==}
     engines: {node: '>=10'}
 
+  p-limit@5.0.0:
+    resolution: {integrity: sha512-/Eaoq+QyLSiXQ4lyYV23f14mZRQcXnxfHrN0vCai+ak9G0pp9iEQukIIZq5NccEvwRB8PUnZT0KsOoDCINS1qQ==}
+    engines: {node: '>=18'}
+
   p-locate@4.1.0:
     resolution: {integrity: sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==}
     engines: {node: '>=8'}
@@ -3917,6 +3924,10 @@ packages:
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
+
+  yocto-queue@1.0.0:
+    resolution: {integrity: sha512-9bnSc/HEW2uRy67wc+T8UwauLuPJVn28jb+GtJY16iiKWyvmYJRXVT4UamsAEGQfPohgr2q4Tq0sQbQlxTfi1g==}
+    engines: {node: '>=12.20'}
 
   zip-dir@2.0.0:
     resolution: {integrity: sha512-uhlsJZWz26FLYXOD6WVuq+fIcZ3aBPGo/cFdiLlv3KNwpa52IF3ISV8fLhQLiqVu5No3VhlqlgthN6gehil1Dg==}
@@ -7291,6 +7302,10 @@ snapshots:
     dependencies:
       yocto-queue: 0.1.0
 
+  p-limit@5.0.0:
+    dependencies:
+      yocto-queue: 1.0.0
+
   p-locate@4.1.0:
     dependencies:
       p-limit: 2.3.0
@@ -8386,6 +8401,8 @@ snapshots:
   yn@3.1.1: {}
 
   yocto-queue@0.1.0: {}
+
+  yocto-queue@1.0.0: {}
 
   zip-dir@2.0.0:
     dependencies:

--- a/src/background.ts
+++ b/src/background.ts
@@ -87,25 +87,21 @@ async function sendTask(tabId: number, messageId: string, data: string): Promise
     return;
   }
 
-  // Build requests to all hosts while firing them in parallel.
-  const hosts = await getHosts();
-  const requests = [];
-  for (const host of hosts) {
-    try {
+  try {
+    // Build requests to all hosts while firing them in parallel.
+    const hosts = await getHosts();
+    const requests = [];
+    for (const host of hosts) {
       requests.push(host.send(data));
+    }
+
+    // Wait for all requests to finish.
+    try {
+      await Promise.allSettled(requests);
     } catch (err) {
       //
     }
-  }
 
-  // Wait for all requests to finish.
-  try {
-    await Promise.allSettled(requests);
-  } catch (err) {
-    //
-  }
-
-  try {
     sendToContent(tabId, MessageAction.SendTaskDone, { messageId });
   } catch (err) {
     const message = err instanceof Error ? err.message : `${err}`;

--- a/src/background.ts
+++ b/src/background.ts
@@ -87,16 +87,25 @@ async function sendTask(tabId: number, messageId: string, data: string): Promise
     return;
   }
 
-  try {
-    const hosts = await getHosts();
-    for (const host of hosts) {
-      try {
-        await host.send(data);
-      } catch (err) {
-        //
-      }
+  // Build requests to all hosts while firing them in parallel.
+  const hosts = await getHosts();
+  const requests = [];
+  for (const host of hosts) {
+    try {
+      requests.push(host.send(data));
+    } catch (err) {
+      //
     }
+  }
 
+  // Wait for all requests to finish.
+  try {
+    await Promise.allSettled(requests);
+  } catch (err) {
+    //
+  }
+
+  try {
     sendToContent(tabId, MessageAction.SendTaskDone, { messageId });
   } catch (err) {
     const message = err instanceof Error ? err.message : `${err}`;


### PR DESCRIPTION
I noticed Competitive Companion is getting slower with time, and it's mainly due to the fact that:

1. The number of custom hosts (ports to send the parsed problems to) has increased significantly;
2. We issue requests to those hosts serially (N requests, but usually only 1 really matters), regardless of whether they were good or not.

By making these requests in parallel, we can get a ~8x speed-up in contest parsing.

Serial calls:

![slow_cc](https://github.com/jmerle/competitive-companion/assets/4999965/1e4fffea-a9c8-411d-b265-e2fb27e35f57)

Parallel calls:

![fast_cc](https://github.com/jmerle/competitive-companion/assets/4999965/9b03c9c2-9a74-44f1-8257-abc04a9bf7a1)

Will be happy to do any other changes deemed necessary to get this through, the speed up was really helpful for me.

EDIT:

It's worth mentioning that I'm using WSL, and I'm not sure the extension is particularly slow because of that. Since it seems the code is like this for a long time, maybe the impact isn't noticeable in most of the cases (well, I expected a few localhost calls to be super fast, even if serialized).

But anyways, I'm getting super slow parses in WSL and this solves that. Maybe other users will benefit from this as well.