### PR TITLE
Allow problems from courses

### DIFF
--- a/src/parsers/problem/KattisProblemParser.ts
+++ b/src/parsers/problem/KattisProblemParser.ts
@@ -7,6 +7,7 @@ export class KattisProblemParser extends Parser {
   public getMatchPatterns(): string[] {
     return [
       'https://*.kattis.com/problems/*',
+      'https://*.kattis.com/*/problems/*',
       'https://*.kattis.com/contests/*/problems/*',
       'https://*.kattis.com/sessions/*/problems/*',
       'https://*.kattis.com/challenge/*',


### PR DESCRIPTION
I just add one more matching path for Kattis problems, so that the URL matches links such as 
https://tamu.kattis.com/courses/CSCE430/2025Spring/assignments/jzms2e/problems/carrots. 