### PR TITLE
Add AYOJ support using the existing DMOJ problem & contest parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ A browser extension which parses competitive programming problems from various o
 | AlgoZenith                 | ✔              |                |
 | Anarchy Golf               | ✔              |                |
 | AtCoder                    | ✔              | ✔              |
+| A.Y. Jackson Online Judge  | ✔              | ✔              |
 | Baekjoon Online Judge      | ✔              |                |
 | BAPS OJ                    | ✔              | ✔              |
 | beecrowd                   | ✔              | ✔              |

--- a/src/parsers/problem/DMOJProblemParser.ts
+++ b/src/parsers/problem/DMOJProblemParser.ts
@@ -9,7 +9,7 @@ export class DMOJProblemParser extends Parser {
     'arena.moi': 'MOI Arena',
     'lqdoj.edu.vn': 'Le Quy Don Online Judge',
     'oj.vnoi.info': 'VNOI Online Judge',
-    'ayjcoding.club': 'A.Y. Jackson Online Judge'
+    'ayjcoding.club': 'A.Y. Jackson Online Judge',
   };
 
   public getMatchPatterns(): string[] {

--- a/src/parsers/problem/DMOJProblemParser.ts
+++ b/src/parsers/problem/DMOJProblemParser.ts
@@ -9,6 +9,7 @@ export class DMOJProblemParser extends Parser {
     'arena.moi': 'MOI Arena',
     'lqdoj.edu.vn': 'Le Quy Don Online Judge',
     'oj.vnoi.info': 'VNOI Online Judge',
+    'ayjcoding.club': 'A.Y. Jackson Online Judge'
   };
 
   public getMatchPatterns(): string[] {


### PR DESCRIPTION
Currently, attempting to use the extension on AYOJ (https://ayjcoding.club/) gives an error. This can be easily fixed by using the already implemented DMOJ problem and contest parsers, which works as expected.