### PR TITLE
Add contest parser for MarisaOJ

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ A browser extension which parses competitive programming problems from various o
 | LightOJ                    | ✔              | ✔              |
 | LSYOI                      | ✔              |                |
 | Luogu                      | ✔              | ✔              |
-| MarisaOJ                   | ✔              |                |
+| MarisaOJ                   | ✔              | ✔              |
 | Mendo                      | ✔              |                |
 | Meta Coding Competitions   | ✔              |                |
 | MOI Arena                  | ✔              | ✔              |

--- a/src/parsers/contest/MarisaOJContestParser.ts
+++ b/src/parsers/contest/MarisaOJContestParser.ts
@@ -1,0 +1,11 @@
+import { MarisaOJProblemParser } from '../problem/MarisaOJProblemParser';
+import { SimpleContestParser } from '../SimpleContestParser';
+
+export class MarisaOJContestParser extends SimpleContestParser {
+  protected linkSelector = '.problem-table tbody > tr > td:nth-child(2) > a';
+  protected problemParser = new MarisaOJProblemParser();
+
+  public getMatchPatterns(): string[] {
+    return ['https://marisaoj.com/mashup/*'];
+  }
+}

--- a/src/parsers/parsers.ts
+++ b/src/parsers/parsers.ts
@@ -32,6 +32,7 @@ import { LanqiaoContestParser } from './contest/LanqiaoContestParser';
 import { LibreOJContestParser } from './contest/LibreOJContestParser';
 import { LightOJContestParser } from './contest/LightOJContestParser';
 import { LuoguContestParser } from './contest/LuoguContestParser';
+import { MarisaOJContestParser } from './contest/MarisaOJContestParser';
 import { NBUTOnlineJudgeContestParser } from './contest/NBUTOnlineJudgeContestParser';
 import { NOJContestParser } from './contest/NOJContestParser';
 import { OpenJudgeContestParser } from './contest/OpenJudgeContestParser';
@@ -299,6 +300,7 @@ export const parsers: Parser[] = [
   new LuoguContestParser(),
 
   new MarisaOJProblemParser(),
+  new MarisaOJContestParser(),
 
   new MendoProblemParser(),
 

--- a/src/parsers/problem/MarisaOJProblemParser.ts
+++ b/src/parsers/problem/MarisaOJProblemParser.ts
@@ -5,7 +5,7 @@ import { Parser } from '../Parser';
 
 export class MarisaOJProblemParser extends Parser {
   public getMatchPatterns(): string[] {
-    return ['https://marisaoj.com/problem/*'];
+    return ['https://marisaoj.com/problem/*', 'https://marisaoj.com/mashup/*/problem/*'];
   }
 
   public async parse(url: string, html: string): Promise<Sendable> {


### PR DESCRIPTION
Example contest url: https://marisaoj.com/mashup/267
Example contest problem url: https://marisaoj.com/mashup/267/problem/667

To be able to access the contest urls, you need to create an account and enroll in a contest in https://marisaoj.com/competitions