### PR TITLE
custom host by optional_host_permissions

### DIFF
--- a/scripts/build/extension.ts
+++ b/scripts/build/extension.ts
@@ -33,6 +33,7 @@ await Promise.all(
 
           permissions: ['activeTab', 'contextMenus', 'storage', 'scripting'],
           host_permissions: ['http://localhost/'],
+          optional_host_permissions: ['*://*/'],
 
           icons: {
             '16': 'icons/icon-16.png',

--- a/src/hosts/CustomHost.ts
+++ b/src/hosts/CustomHost.ts
@@ -1,12 +1,15 @@
 import { Host } from './Host';
 
 export class CustomHost extends Host {
-  public constructor(private port: number) {
+  public constructor(
+    private host: string,
+    private port: number,
+  ) {
     super();
   }
 
   public async send(data: string): Promise<void> {
-    await this.doSend(`http://localhost:${this.port}/`, {
+    await this.doSend(`http://${this.host}:${this.port}/`, {
       body: data,
       headers: {
         'Content-Type': 'application/json',

--- a/src/hosts/hosts.ts
+++ b/src/hosts/hosts.ts
@@ -3,7 +3,7 @@ import { CHelperHost } from './CHelperHost';
 import { CustomHost } from './CustomHost';
 import { Host } from './Host';
 
-const defaultHosts: Host[] = [new CHelperHost()];
+const defaultHosts = ['localhost'];
 const defaultPorts = [
   1327, // cpbooster
   4244, // Hightail
@@ -15,7 +15,18 @@ const defaultPorts = [
 ];
 
 export async function getHosts(): Promise<Host[]> {
+  const customHosts = await config.get('customHosts');
+  const uniqueHosts = [...new Set(defaultHosts.concat(customHosts))];
+
   const customPorts = await config.get('customPorts');
   const uniquePorts = [...new Set(defaultPorts.concat(customPorts))];
-  return defaultHosts.concat(uniquePorts.map(port => new CustomHost(port)));
+
+  const hosts: Host[] = [new CHelperHost()];
+  uniqueHosts.map(host => {
+    uniquePorts.map(port => {
+      hosts.push(new CustomHost(host, port));
+    });
+  });
+
+  return hosts;
 }

--- a/src/options.html
+++ b/src/options.html
@@ -57,6 +57,23 @@
   <body>
     <section>
       <h3>Custom tools</h3>
+      <label for="custom-hosts">Custom hosts</label>
+
+      <br />
+
+      <input type="text" id="custom-hosts" title="Hosts" />
+
+      <p id="custom-hosts-error" class="error hidden">
+        Please make sure all hosts are valid, and multiple hosts are separated by commas.
+      </p>
+
+      <p class="description">
+        Specify custom hosts to send the parsed data to, separated by commas. Each host must not contain https:// or
+        http://.
+      </p>
+
+      <br />
+
       <label for="custom-ports">Custom ports</label>
 
       <br />

--- a/src/options.ts
+++ b/src/options.ts
@@ -1,6 +1,7 @@
 import { config } from './utils/config';
 import { noop } from './utils/noop';
 
+const customHostsInput = document.querySelector<HTMLInputElement>('#custom-hosts');
 const customPortsInput = document.querySelector<HTMLInputElement>('#custom-ports');
 const customRulesContainer = document.querySelector<HTMLDivElement>('#custom-rules-container');
 const requestTimeoutInput = document.querySelector<HTMLInputElement>('#request-timeout');
@@ -96,6 +97,43 @@ function addCustomRulesRow(regex?: string, parserName?: string): void {
 
   customRulesContainer.appendChild(row);
 }
+
+async function fillCustomValues(): Promise<void> {
+  const customHosts = await config.get('customHosts');
+  const customPorts = await config.get('customPorts');
+  const customRules = await config.get('customRules');
+
+  customHostsInput.value = customHosts.join(',');
+  customPortsInput.value = customPorts.join(',');
+  customRulesContainer.innerHTML = '';
+
+  for (const rule of customRules) {
+    addCustomRulesRow(rule[0], rule[1]);
+  }
+
+  addCustomRulesRow();
+}
+
+window.addEventListener('load', fillCustomValues);
+
+customHostsInput.addEventListener('input', function (): void {
+  const hosts = this.value
+    .split(',')
+    .map(x => x.trim())
+    .filter(x => x.length > 0);
+
+  const uniqueHosts = [...new Set(hosts)];
+
+  const errorElem = document.querySelector('#custom-hosts-error');
+
+  if (uniqueHosts.some(x => x.includes('https://') || x.includes('http://'))) {
+    errorElem.classList.remove('hidden');
+  } else {
+    errorElem.classList.add('hidden');
+
+    config.set('customHosts', uniqueHosts).then(noop).catch(noop);
+  }
+});
 
 customPortsInput.addEventListener('input', function (): void {
   const ports = this.value

--- a/src/options.ts
+++ b/src/options.ts
@@ -147,9 +147,9 @@ customPortsInput.addEventListener('input', function (): void {
   const errorElem = document.querySelector('#custom-ports-error');
 
   if (uniquePorts.some(isNaN) || uniquePorts.some(x => x < 0)) {
-    errorElem.classList.add('hidden');
-  } else {
     errorElem.classList.remove('hidden');
+  } else {
+    errorElem.classList.add('hidden');
 
     config.set('customPorts', uniquePorts).then(noop).catch(noop);
   }

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -1,6 +1,7 @@
 import { browser } from './browser';
 
 interface ConfigItems {
+  customHosts: string[];
   customPorts: number[];
   customRules: [string, string][];
   requestTimeout: number;
@@ -9,6 +10,7 @@ interface ConfigItems {
 
 class Config {
   private readonly defaults: Partial<ConfigItems> = {
+    customHosts: [],
     customPorts: [],
     customRules: [],
     requestTimeout: 500,


### PR DESCRIPTION
# what I implemented
- former pull request's code as this PR extends
    - #541
    - #544
- including few changes that jmerle commited before merging (style fix, hostname consistency)
- set `optional_host_permissions` to wildcard.
---
- i've checked Content-Type header set to be `application/json` because #549 
![image](https://github.com/user-attachments/assets/2fbad274-29a5-48eb-86cd-7f1865ef4b20)
---
I've checked those environments work fine on baekjoon online judge.
- cpeditor
- vs code + cph extension
- code-server(hosted via server) + cph extension

# limitation
- The current PR requires CORS settings on the server to send requests to the server.
- I don't think this is an issue that should be addressed in this extension
- External servers can solve this problem through proxy server like nginx, etc.

# note
- I think that call `fetch` function at background script in Extension might solve this current limitation.
- But I think this might be okay in that this doesn't require much modification.

If there is anything you would like me to improve, feel free to request me.