### PR TITLE
Fix PTA (pintia.cn) parser bug

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "competitive-companion",
   "productName": "Competitive Companion",
-  "version": "2.62.0",
+  "version": "2.62.3",
   "description": "Parses competitive programming problems and sends them to various tools like CP Editor and CPH.",
   "repository": "https://github.com/jmerle/competitive-companion",
   "author": "Jasper van Merle",

--- a/src/parsers/problem/PTAProblemParser.ts
+++ b/src/parsers/problem/PTAProblemParser.ts
@@ -12,22 +12,40 @@ export class PTAProblemParser extends Parser {
     const elem = htmlToElement(html);
     const task = new TaskBuilder('PTA').setUrl(url);
 
-    const container = elem.querySelector('div[class^="mn"] div[class^="left"]');
+    const container = elem.querySelector('.scroll');
 
-    task.setName(container.querySelector('span.font-bold').textContent.trim());
-    task.setCategory(elem.querySelector('.fixed.top-0.w-full .text-lg.ellipsis').textContent.trim());
+    task.setName(
+      container.querySelector('.text-darkest.font-bold.text-lg')!.textContent!.trim()
+    );
+    const categoryEl = elem.querySelector('.fixed.top-0.w-full .text-lg.ellipsis');
+    task.setCategory(categoryEl ? categoryEl.textContent!.trim() : '');
 
-    const limits = [...container.querySelectorAll('div[class*="problemInfo"] .pc-text-raw')].map(l => l.textContent);
-    const timeLimitStr = limits.find(text => text.includes('MB'));
-    const memoryLimitStr = limits.find(text => text.includes('ms'));
+    const limits = [...elem.querySelectorAll('.problemInfo_tfBoz .pc-text-raw')].map(
+      (l) => l.textContent || ''
+    );
+
+    const timeLimitStr = limits.find(text => text.includes('ms'));
+    const memoryLimitStr = limits.find(text => text.includes('MB'));
 
     task.setTimeLimit(parseInt(/(\d+)/.exec(timeLimitStr)[1], 10));
     task.setMemoryLimit(parseInt(/(\d+)/.exec(memoryLimitStr)[1], 10));
 
-    const blocks = [...container.querySelectorAll('.rendered-markdown > pre > code:not(.hljs)')];
+    const inputHeader = elem.querySelector('h3[id*="输入样例"]');
+    const outputHeader = elem.querySelector('h3[id*="输出样例"]');
+    
+    if (inputHeader && outputHeader) {
+      const inputCode = inputHeader.nextElementSibling?.querySelector('code')?.textContent?.trim();
+      const outputCode = outputHeader.nextElementSibling?.querySelector('code')?.textContent?.trim();
+      
+      if (inputCode && outputCode) {
+        task.addTest(inputCode, outputCode);
+      }
+    } else {
+      const blocks = [...elem.querySelectorAll('.rendered-markdown pre > code:not(.hljs)')];
 
-    for (let i = 0; i < blocks.length - 1; i += 2) {
-      task.addTest(blocks[i].textContent, blocks[i + 1].textContent);
+      for (let i = 0; i < blocks.length - 1; i += 2) {
+        task.addTest(blocks[i].textContent, blocks[i + 1].textContent);
+      }
     }
 
     return task.build();


### PR DESCRIPTION
# Summary
This PR reports and fixes issues in the PTA (pintia.cn) parser (`PTAProblemParser.ts`) of Competitive Companion.  
The previous implementation had problems parsing metadata and examples. I’ve updated the parser and tested it locally.

# What was wrong
- Time and memory limits were parsed in the wrong order.  
- Problem title and category selectors no longer matched PTA’s latest DOM.  
- Sample input/output blocks were not selected correctly.  

# Changes
- Updated selectors for container, title, and category to match PTA’s current DOM.  
- Fixed time/memory limit parsing (they were reversed before).  
- Improved sample input/output parsing:  
  - Prefer `h3[id*="输入样例"]` and `h3[id*="输出样例"]`.  
  - Fallback to `.rendered-markdown pre > code:not(.hljs)` when headers are missing.  

# New function
Added an improved parsing strategy for examples, which is more accurate but slightly more resource-intensive.  

# Note
This is my first GitHub pull request, so please forgive any mistakes and feel free to give me feedback.  

Closes #637