### PR TITLE
Add NowCoder contest parser and update problem parser

### DIFF
--- a/src/parsers/contest/NowCoderContestParser.ts
+++ b/src/parsers/contest/NowCoderContestParser.ts
@@ -1,0 +1,11 @@
+import { NowCoderProblemParser } from '../problem/NowCoderProblemParser';
+import { SimpleContestParser } from '../SimpleContestParser';
+
+export class NowCoderContestParser extends SimpleContestParser {
+  protected linkSelector = 'table tr td:nth-child(2) a';
+  protected problemParser = new NowCoderProblemParser();
+
+  public getMatchPatterns(): string[] {
+    return ['https://ac.nowcoder.com/acm/contest/*'];
+  }
+}

--- a/src/parsers/parsers.ts
+++ b/src/parsers/parsers.ts
@@ -37,6 +37,7 @@ import { LuoguContestParser } from './contest/LuoguContestParser';
 import { MarisaOJContestParser } from './contest/MarisaOJContestParser';
 import { NBUTOnlineJudgeContestParser } from './contest/NBUTOnlineJudgeContestParser';
 import { NOJContestParser } from './contest/NOJContestParser';
+import { NowCoderContestParser } from './contest/NowCoderContestParser';
 import { OpenJudgeContestParser } from './contest/OpenJudgeContestParser';
 import { PEGJudgeContestParser } from './contest/PEGJudgeContestParser';
 import { POJContestParser } from './contest/POJContestParser';
@@ -337,6 +338,7 @@ export const parsers: Parser[] = [
   new NOJContestParser(),
 
   new NowCoderProblemParser(),
+  new NowCoderContestParser(),
 
   new OlinfoProblemParser(),
 


### PR DESCRIPTION
Introduces NowCoderContestParser for contest parsing and registers it in the parsers list. Updates NowCoderProblemParser to support new practice problem URLs and refactors the parsing logic for practice problems, including improved extraction of limits and test cases.

**NowCoder**
contest example：https://ac.nowcoder.com/acm/contest/119666
problem example：https://ac.nowcoder.com/acm/problem/305093
problem example：https://www.nowcoder.com/practice/12da4185c0bb45918cfdc3072e544069?tpId=383&tqId=11211624&channelPut=w251acm