### PR TITLE
Add lazycph to list of tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,10 +34,10 @@ A browser extension which parses competitive programming problems from various o
 - [Fast Olympic Coding](https://github.com/sam20908/vscode-fastolympiccoding)
 - [Hightail](https://github.com/dj3500/hightail)
 - [JHelper](https://plugins.jetbrains.com/plugin/7541-jhelper)
+- [LazyCPH](https://github.com/TheComputerM/lazycph)
 - [Mind Sport](https://plugins.jetbrains.com/plugin/10688-mind-sport)
 - [Red Panda Dev-C++](https://github.com/royqh1979/RedPanda-CPP)
 - [rust-competitive-helper](https://github.com/rust-competitive-helper/rust-competitive-helper)
-- [lazycph](https://github.com/TheComputerM/lazycph)
 - Any other tool that can parse the data that is being sent, read more about that [below](#custom-tools)
 
 ## Supported websites


### PR DESCRIPTION
Name: LazyCPH
Link: https://github.com/TheComputerM/lazycph?tab=readme-ov-file#with-competitive-companion

> If you want your own tool added to the released version of Competitive Companion, [create an issue](https://github.com/jmerle/competitive-companion/issues/new) in this repository specifying the name and a link to the tool.

I didn't understand if this meant I should create an issue specifically to get a free port for lazycph, but I did both just in case.