### PR TITLE
Update selector for content extraction in parser

### DIFF
--- a/src/parsers/problem/SSOIERProblemParser.ts
+++ b/src/parsers/problem/SSOIERProblemParser.ts
@@ -16,7 +16,7 @@ export class SSOIERProblemParser extends Parser {
     const elem = htmlToElement(html);
     const task = new TaskBuilder('SSOIER').setUrl(url);
 
-    const container = elem.querySelector('td.pcontent');
+    const container = elem.querySelector('body>center>center td');
 
     task.setName(container.querySelector('h3').textContent);
 

--- a/src/parsers/problem/SSOIERProblemParser.ts
+++ b/src/parsers/problem/SSOIERProblemParser.ts
@@ -16,7 +16,7 @@ export class SSOIERProblemParser extends Parser {
     const elem = htmlToElement(html);
     const task = new TaskBuilder('SSOIER').setUrl(url);
 
-    const container = elem.querySelector('body>center>center td');
+    const container = elem.querySelector('body > center > center td');
 
     task.setName(container.querySelector('h3').textContent);
 


### PR DESCRIPTION
no class='pcontent' in problem page now.
'body>center>center td' can fix it, just for now.