### PR TITLE
Fix Vjudge parser for updated group contest UI

### DIFF
--- a/src/parsers/contest/VirtualJudgeContestParser.ts
+++ b/src/parsers/contest/VirtualJudgeContestParser.ts
@@ -5,7 +5,13 @@ import { request } from '../../utils/request';
 import { ContestParser } from '../ContestParser';
 import { VirtualJudgeProblemParser } from '../problem/VirtualJudgeProblemParser';
 
-export class VirtualJudgeContestParser extends ContestParser<[string, string, any]> {
+interface VjudgeProblemEntry {
+  num: string;
+  title: string;
+  descKey: string;
+}
+
+export class VirtualJudgeContestParser extends ContestParser<[string, string, VjudgeProblemEntry]> {
   private problemParser = new VirtualJudgeProblemParser();
 
   public getMatchPatterns(): string[] {
@@ -16,37 +22,84 @@ export class VirtualJudgeContestParser extends ContestParser<[string, string, an
     return document.querySelector('#contest-problems tr > .prob-title > a') !== null;
   }
 
-  protected async getTasksToParse(html: string, url: string): Promise<[string, string, any][]> {
+  protected async getTasksToParse(html: string, url: string): Promise<[string, string, VjudgeProblemEntry][]> {
     const elem = htmlToElement(html);
-    const category = elem.querySelector('#time-info > .row > .col-xs-6 > h3').textContent.trim();
 
-    const data = JSON.parse(elem.querySelector<HTMLTextAreaElement>('textarea[name="dataJson"]').value);
-    return data.problems.map((problem: any) => [url, category, problem]);
+    // The contest title is now in a plain h3 within the page header.
+    // Previously it was nested as #time-info > .row > .col-xs-6 > h3.
+    const categoryEl =
+      elem.querySelector<HTMLElement>('#time-info h3') ??
+      elem.querySelector<HTMLElement>('h3');
+    const category = categoryEl ? categoryEl.textContent.trim() : 'Virtual Judge';
+
+    // The old `textarea[name="dataJson"]` blob no longer exists.
+    // Problem data is now rendered as a table in #contest-problems.
+    // Each row contains:
+    //   - A letter cell in the `#` column
+    //   - A `.prob-title a[href="#problem/X"]` link with the display title
+    //   - A PDF link `/contest/{id}/problemPdf/{letter}?descKey={key}` that
+    //     exposes the descKey required by the description API.
+    const rows = [...elem.querySelectorAll<HTMLTableRowElement>('#contest-problems tr')];
+
+    const problems: VjudgeProblemEntry[] = [];
+    for (const row of rows) {
+      const titleLink = row.querySelector<HTMLAnchorElement>('.prob-title a');
+      if (titleLink === null) continue;
+
+      // Problem letter: the href is "#problem/A", so take the last segment.
+      const hrefLetter = titleLink.getAttribute('href')?.split('/').pop() ?? '';
+
+      // descKey is embedded in the PDF download link href as a query parameter.
+      const pdfLink = row.querySelector<HTMLAnchorElement>(`a[href*="/problemPdf/"]`);
+      const descKey = pdfLink
+        ? new URL(pdfLink.href, 'https://vjudge.net').searchParams.get('descKey') ?? ''
+        : '';
+
+      problems.push({
+        num: hrefLetter,
+        title: titleLink.textContent.trim(),
+        descKey,
+      });
+    }
+
+    return problems.map(p => [url, category, p]);
   }
 
-  protected async parseTask([url, category, data]: [string, string, any]): Promise<Task> {
-    const task = new TaskBuilder('Virtual Judge').setUrl(`${url.split('#')[0]}#problem/${data.num}`);
+  protected async parseTask([url, category, data]: [string, string, VjudgeProblemEntry]): Promise<Task> {
+    const contestUrl = url.split('#')[0];
+    const task = new TaskBuilder('Virtual Judge').setUrl(`${contestUrl}#problem/${data.num}`);
 
     task.setName(`${data.num} - ${data.title}`);
     task.setCategory(category);
 
-    for (const property of data.properties) {
-      if (property.title == 'Time limit') {
-        task.setTimeLimit(parseFloat(property.content.split(' ')[0]));
-      } else if (property.title == 'Memory limit' || property.title == 'Mem limit') {
-        task.setMemoryLimit(parseFloat(property.content.split(' ')[0]) / 1024);
+    // Fetch limits and sample tests from the description API.
+    // The API endpoint is unchanged; we now source descKey from the PDF link.
+    if (data.descKey) {
+      const descriptionUrl = `https://vjudge.net/problem/description/${data.descKey}`;
+      const description = await request(descriptionUrl, { credentials: 'same-origin' });
+      const descElem = htmlToElement(description);
+      const jsonContainer = descElem.querySelector('.data-json-container');
+
+      if (jsonContainer !== null) {
+        const json = JSON.parse(jsonContainer.textContent);
+
+        // Parse time/memory limits from the description JSON metadata.
+        if (Array.isArray(json.properties)) {
+          for (const property of json.properties) {
+            const titleLower: string = (property.title ?? '').toLowerCase();
+            if (titleLower === 'time limit') {
+              task.setTimeLimit(parseFloat(property.content.split(' ')[0]));
+            } else if (titleLower === 'memory limit' || titleLower === 'mem limit') {
+              task.setMemoryLimit(parseFloat(property.content.split(' ')[0]) / 1024);
+            }
+          }
+        }
+
+        const codeBlocks = this.problemParser.getCodeBlocksFromDescription(json);
+        for (let i = 0; i < codeBlocks.length - 1; i += 2) {
+          task.addTest(codeBlocks[i], codeBlocks[i + 1]);
+        }
       }
-    }
-
-    const latestVersion = data.descBriefs[data.descBriefs.length - 1];
-    const descriptionUrl = `https://vjudge.net/problem/description/${latestVersion.key}?${latestVersion.version}`;
-    const description = await request(descriptionUrl, { credentials: 'same-origin' });
-    const jsonContainer = htmlToElement(description).querySelector('.data-json-container');
-    const json = JSON.parse(jsonContainer.textContent);
-
-    const codeBlocks = this.problemParser.getCodeBlocksFromDescription(json);
-    for (let i = 0; i < codeBlocks.length - 1; i += 2) {
-      task.addTest(codeBlocks[i], codeBlocks[i + 1]);
     }
 
     return task.build();

--- a/src/parsers/problem/VirtualJudgeProblemParser.ts
+++ b/src/parsers/problem/VirtualJudgeProblemParser.ts
@@ -20,14 +20,35 @@ export class VirtualJudgeProblemParser extends Parser {
     const elem = htmlToElement(html);
     const task = new TaskBuilder('Virtual Judge').setUrl(url);
 
-    if (elem.querySelector('#problem-title') === null) {
-      task.setName(elem.querySelector('#prob-title > h2').textContent.trim());
-      task.setCategory(window.location.href.split('/').pop().split('-')[0]);
-    } else {
+    // --- Title ---
+    // Old UI had #problem-title (standalone problem page) or #prob-title > h2 (contest page).
+    // New UI renders a plain <h2> in the problem content area on contest pages;
+    // standalone /problem/* pages still use h2#problem-title.
+    if (elem.querySelector('h2#problem-title') !== null) {
       task.setName(elem.querySelector('h2#problem-title').textContent.trim());
-      task.setCategory(elem.querySelector('#time-info > .row > .col-xs-6 > h3').textContent.trim());
+    } else {
+      // New contest UI: first <h2> inside the main problem content panel.
+      const h2 = elem.querySelector<HTMLElement>('.prob-main h2, #prob-main h2, h2');
+      task.setName(h2 ? h2.textContent.trim() : '');
     }
 
+    // --- Category ---
+    // Old UI: #time-info > .row > .col-xs-6 > h3 (now gone from contests).
+    // New UI: a plain <h3> directly inside #time-info (contest title area).
+    // Standalone /problem/* pages: derive from URL as before.
+    if (url.includes('/contest/')) {
+      const catEl =
+        elem.querySelector<HTMLElement>('#time-info h3') ??
+        elem.querySelector<HTMLElement>('h3');
+      task.setCategory(catEl ? catEl.textContent.trim() : 'Virtual Judge');
+    } else {
+      // Standalone problem page: category is the OJ prefix, e.g. "CodeForces" from "CodeForces-1A".
+      task.setCategory(window.location.href.split('/').pop().split('-')[0]);
+    }
+
+    // --- Time / Memory limits ---
+    // The <dt> labels have stayed; however the sibling is now a plain <div class="value">
+    // instead of a <dd> in the new sidebar layout. We handle both via nextElementSibling.
     const timeLimitDt = [...elem.querySelectorAll('dt')].find(el =>
       el.textContent.toLowerCase().includes('time limit'),
     );
@@ -68,32 +89,71 @@ export class VirtualJudgeProblemParser extends Parser {
       });
     }
 
+    // --- Sample tests ---
     try {
       if (url.includes('UVA-') || url.includes('UVALive-')) {
-        const iframe = [...elem.querySelectorAll<HTMLIFrameElement>('#prob-right-panel iframe')].find(
-          el => el.style.display !== 'none',
+        // UVa problems are delivered as PDFs.
+        // Old UI: embedded via an iframe whose src pointed to a CDN PDF.
+        // New UI: a direct PDF link with id="btn-contest-problem-pdf" or similar.
+        const pdfBtn = elem.querySelector<HTMLAnchorElement>(
+          '#btn-contest-problem-pdf, a[href*="problemPdf"], a[href$=".pdf"]',
         );
 
-        const iframeContent = await request(iframe.src);
-        const pdfId = /CDN_BASE_URL\/([^?]+)\?v/.exec(iframeContent)[1];
-
-        const pdfLines = await readPdf(`https://vj.csgrandeur.cn/${pdfId}`);
-
-        const uvaParser = new UVaOnlineJudgeProblemParser();
-        await uvaParser.parseTestsFromPdf(task, pdfLines);
+        if (pdfBtn !== null) {
+          const pdfContent = await request(pdfBtn.href);
+          const pdfId = /CDN_BASE_URL\/([^?]+)\?v/.exec(pdfContent)?.[1];
+          if (pdfId) {
+            const pdfLines = await readPdf(`https://vj.csgrandeur.cn/${pdfId}`);
+            const uvaParser = new UVaOnlineJudgeProblemParser();
+            await uvaParser.parseTestsFromPdf(task, pdfLines);
+          }
+        } else {
+          // Fallback to old iframe approach in case the old UI is encountered.
+          const iframe = [...elem.querySelectorAll<HTMLIFrameElement>('#prob-right-panel iframe')].find(
+            el => el.style.display !== 'none',
+          );
+          if (iframe !== undefined) {
+            const iframeContent = await request(iframe.src);
+            const pdfId = /CDN_BASE_URL\/([^?]+)\?v/.exec(iframeContent)[1];
+            const pdfLines = await readPdf(`https://vj.csgrandeur.cn/${pdfId}`);
+            const uvaParser = new UVaOnlineJudgeProblemParser();
+            await uvaParser.parseTestsFromPdf(task, pdfLines);
+          }
+        }
       } else if (!url.includes('TopCoder-')) {
-        const iframe = [...elem.querySelectorAll<HTMLIFrameElement>('#prob-right-panel iframe')].find(
-          el => el.style.display !== 'none',
-        );
+        // New UI: the descKey is embedded in the PDF download button href as
+        // `/contest/{id}/problemPdf/{letter}?descKey={key}`.
+        // Standalone problem pages use a different button.
+        const descKey = this.extractDescKey(elem);
 
-        const iframeUrl = iframe.src;
-        const iframeContent = await request(iframeUrl);
-        const jsonContainer = htmlToElement(iframeContent).querySelector('.data-json-container');
-        const json = JSON.parse(jsonContainer.textContent);
+        if (descKey !== null) {
+          const descriptionUrl = `https://vjudge.net/problem/description/${descKey}`;
+          const description = await request(descriptionUrl, { credentials: 'same-origin' });
+          const jsonContainer = htmlToElement(description).querySelector('.data-json-container');
+          if (jsonContainer !== null) {
+            const json = JSON.parse(jsonContainer.textContent);
+            const codeBlocks = this.getCodeBlocksFromDescription(json);
+            for (let i = 0; i < codeBlocks.length - 1; i += 2) {
+              task.addTest(codeBlocks[i], codeBlocks[i + 1]);
+            }
+          }
+        } else {
+          // Fallback: try the old iframe-based approach (old UI compatibility).
+          const iframe = [...elem.querySelectorAll<HTMLIFrameElement>('#prob-right-panel iframe')].find(
+            el => el.style.display !== 'none',
+          );
 
-        const codeBlocks = this.getCodeBlocksFromDescription(json);
-        for (let i = 0; i < codeBlocks.length - 1; i += 2) {
-          task.addTest(codeBlocks[i], codeBlocks[i + 1]);
+          if (iframe !== undefined) {
+            const iframeUrl = iframe.src;
+            const iframeContent = await request(iframeUrl);
+            const jsonContainer = htmlToElement(iframeContent).querySelector('.data-json-container');
+            const json = JSON.parse(jsonContainer.textContent);
+
+            const codeBlocks = this.getCodeBlocksFromDescription(json);
+            for (let i = 0; i < codeBlocks.length - 1; i += 2) {
+              task.addTest(codeBlocks[i], codeBlocks[i + 1]);
+            }
+          }
         }
       }
     } catch (err) {
@@ -101,6 +161,41 @@ export class VirtualJudgeProblemParser extends Parser {
     }
 
     return task.build();
+  }
+
+  /**
+   * Extracts the description key from the page.
+   *
+   * New UI: the key is in the PDF download button href, e.g.
+   *   /contest/802878/problemPdf/A?descKey=2672272863153537
+   *
+   * Returns null when no such link is found (old UI fallback).
+   */
+  private extractDescKey(elem: Element): string | null {
+    // Contest problem page: PDF button with id or href pattern.
+    const pdfLink = elem.querySelector<HTMLAnchorElement>(
+      '#btn-contest-problem-pdf, a[href*="problemPdf"][href*="descKey"]',
+    );
+    if (pdfLink !== null) {
+      try {
+        return new URL(pdfLink.href, 'https://vjudge.net').searchParams.get('descKey');
+      } catch {
+        // href may be relative or malformed; fall through.
+      }
+    }
+
+    // Standalone /problem/* page: look for a similar link with descKey.
+    const descLinks = [...elem.querySelectorAll<HTMLAnchorElement>('a[href*="descKey"]')];
+    for (const link of descLinks) {
+      try {
+        const key = new URL(link.href, 'https://vjudge.net').searchParams.get('descKey');
+        if (key) return key;
+      } catch {
+        // continue
+      }
+    }
+
+    return null;
   }
 
   public getCodeBlocksFromDescription(json: any): string[] {


### PR DESCRIPTION
## Problem

Vjudge recently updated their UI from a classic multi-page layout to a single-page application. This broke the Vjudge parsers specifically for group/club contests.

## Root Causes

### 1. `textarea[name="dataJson"]` removed (contest parser)
The contest parser previously relied on a hidden textarea containing a full JSON blob with all problem metadata (IDs, titles, time/memory limits, and description keys). **This element no longer exists in the DOM.** This caused an immediate null-pointer crash, making the entire contest parser non-functional.

### 2. Description `#prob-right-panel iframe` removed (problem parser)
The problem parser fetched sample test cases via the src URL of a hidden `<iframe>` inside `#prob-right-panel`. **The iframe is gone.** The description URL and its response format (`.data-json-container` textarea) are unchanged, but the key to construct that URL must now be sourced differently.

### 3. Broken category/title selectors (both parsers)
- `#time-info > .row > .col-xs-6 > h3`: the nested Bootstrap grid wrapper is gone; the `<h3>` is now a direct child of `#time-info`.
- `h2#problem-title` / `#prob-title > h2`: neither exists on the contest problem view; the title is now a plain `<h2>`.

## Fix

### Contest parser (`VirtualJudgeContestParser.ts`)
- **Problem list**: Scrape the `#contest-problems` table rows (still present). Extract the problem letter from the `.prob-title a` href attribute and the **`descKey`** from the PDF download button's href query parameter: `/contest/{id}/problemPdf/{letter}?descKey={key}`.
- **Description fetch**: Use the existing `/problem/description/{descKey}` API (response format unchanged) to fetch sample tests and metadata.
- **Time/memory limits**: Read from the `properties` array in the description API JSON response.
- **Category**: Update selector to `#time-info h3` with fallback to first `h3`.

### Problem parser (`VirtualJudgeProblemParser.ts`)
- **Description source**: Replace iframe lookup with `descKey` extraction from `#btn-contest-problem-pdf` or any `a[href*="descKey"]`. The old iframe approach is kept as a fallback for backward compatibility.
- **Title**: Fall through to a plain `h2` selector when `h2#problem-title` is not found.  
- **Category**: Update to `#time-info h3` for contest pages.

## What was NOT changed
- The `getCodeBlocksFromDescription()` logic is 100% unchanged — the description API response format is the same.
- The `canHandlePage()` guard still works (`#contest-problems .prob-title a` is still present).
- UVa PDF parsing fallback is preserved.
- All existing standalone `/problem/*` page selectors that still work are kept.