### PR TITLE
feat: add XinYouDuiProblemParser for xinyoudui.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,7 @@ A browser extension which parses competitive programming problems from various o
 | Yandex                     | ✔              | ✔              |
 | XXM                        | ✔              |                |
 | X-Camp                     | ✔              |                |
+| XinYouDui                  | ✔              |                |
 | yukicoder                  | ✔              | ✔              |
 | Yun Dou Xue Yuan           | ✔              | ✔              |
 | ZOJ                        | ✔              |                |

--- a/src/parsers/parsers.ts
+++ b/src/parsers/parsers.ts
@@ -160,7 +160,7 @@ import { YandexProblemParser } from './problem/YandexProblemParser';
 import { YukicoderProblemParser } from './problem/YukicoderProblemParser';
 import { ZOJProblemParser } from './problem/ZOJProblemParser';
 import { ZUFEOJProblemParser } from './problem/ZUFEOJProblemParser';
-
+import { XinYouDuiProblemParser } from './problem/XinYouDuiProblemParser'
 export const parsers: Parser[] = [
   new A2OnlineJudgeProblemParser(),
   new A2OnlineJudgeContestParser(),
@@ -410,6 +410,7 @@ export const parsers: Parser[] = [
   new VirtualJudgeContestParser(),
 
   new XCampProblemParser(),
+  new XinYouDuiProblemParser(),
 
   new XXMProblemParser(),
 

--- a/src/parsers/problem/XinYouDuiProblemParser.ts
+++ b/src/parsers/problem/XinYouDuiProblemParser.ts
@@ -1,0 +1,34 @@
+import { Sendable } from '../../models/Sendable';
+import { TaskBuilder } from '../../models/TaskBuilder';
+import { htmlToElement } from '../../utils/dom';
+import { Parser } from '../Parser';
+
+export class XinYouDuiProblemParser extends Parser {
+  public getMatchPatterns(): string[] {
+    return ['https://xinyoudui.com/*/problem/*'];
+  }
+
+  public async parse(url: string, html: string): Promise<Sendable> {
+    const elem = htmlToElement(html);
+    const task = new TaskBuilder('XinYouDui').setUrl(url);
+
+    const nameElem = elem.querySelector('h4.ac-ant-typography');
+    task.setName(nameElem.textContent.replace(/\s\s+/g, ' ').trim());
+
+    let limits = elem.querySelectorAll("div.ac-ant-space > div.ac-ant-space-item > div > blockquote > div > div");
+    let timeLimitStr = limits[0].textContent;
+    task.setTimeLimit(parseInt(timeLimitStr.match(/\d+/)[0], 10));
+    let memoryLimitStr = limits[1].textContent;
+    task.setMemoryLimit(parseInt(memoryLimitStr.match(/\d+/)[0], 10));
+
+    let block = elem.querySelectorAll("pre > div.ac-ant-typography");
+    const len = block.length;
+    if (len) {
+      for (let i = 0; i < len; i += 2) {
+        task.addTest(block[i].textContent, block[i + 1].textContent);
+      }
+    }
+
+    return task.build();
+  }
+}


### PR DESCRIPTION
## Summary

This PR adds support for parsing problems from XinYouDui (`xinyoudui.com`).

A new `XinYouDuiProblemParser` is introduced to extract problem metadata and sample tests from XinYouDui problem pages.

## What changed

- added `XinYouDuiProblemParser`
- matched XinYouDui problem URLs with pattern:
  - `https://xinyoudui.com/*/problem/*`
- parsed the following fields from the problem page:
  - problem title
  - time limit
  - memory limit
  - sample input / output pairs
- converted parsed data into the unified `TaskBuilder` format

## Implementation details

The parser currently:
- extracts the problem title from `h4.ac-ant-typography`
- extracts time limit and memory limit from the corresponding `blockquote` section
- extracts sample test cases from `pre > div.ac-ant-typography`
- adds samples in input/output pairs via `task.addTest(...)`

## Notes

- this PR adds support for XinYouDui only and does not affect existing parsers
- parsing is based on the current XinYouDui page structure

## Tested

Tested on XinYouDui problem pages to confirm:
- title is parsed correctly
- time limit is parsed correctly
- memory limit is parsed correctly
- sample inputs and outputs are paired correctly