### PR TITLE
fix(parser): improved AlgoZenith test case extraction

### DIFF
--- a/src/parsers/problem/AlgoZenithNewProblemParser.ts
+++ b/src/parsers/problem/AlgoZenithNewProblemParser.ts
@@ -12,19 +12,66 @@ export class AlgoZenithNewProblemParser extends Parser {
     const elem = htmlToElement(html);
     const task = new TaskBuilder('AlgoZenith').setUrl(url);
 
-    task.setName(elem.querySelector('h4').textContent);
+    task.setName(
+      elem.querySelector('h1')?.textContent?.trim() ??
+      elem.querySelector('h4')?.textContent?.trim() ??
+      'AlgoZenith Problem',
+    );
 
     const limitElems = elem.querySelectorAll('span.dmsans ~ span.fw-bold');
 
-    const timeLimitStr = limitElems[0].textContent;
-    task.setTimeLimit(parseInt(/(\d+)/.exec(timeLimitStr)[1]) * 1000);
+    const timeLimitStr = limitElems[0]?.textContent ?? '';
+    const timeLimitMatch = /(\d+)/.exec(timeLimitStr);
+    if (timeLimitMatch) {
+      task.setTimeLimit(parseInt(timeLimitMatch[1]) * 1000);
+    }
 
-    const memoryLimitStr = limitElems[1].textContent;
-    task.setMemoryLimit(parseInt(/(\d+)/.exec(memoryLimitStr)[1]));
+    const memoryLimitStr = limitElems[1]?.textContent ?? '';
+    const memoryLimitMatch = /(\d+)/.exec(memoryLimitStr);
+    if (memoryLimitMatch) {
+      task.setMemoryLimit(parseInt(memoryLimitMatch[1]));
+    }
 
-    const blocks = elem.querySelectorAll('.mt-4 div[class^="coding_input_format__"]');
-    for (let i = 0; i < blocks.length - 1; i += 2) {
-      task.addTest(blocks[i].textContent, blocks[i + 1].textContent);
+    // AZ uses "Input" and "Desired Output" labels for test cases
+    const labels = Array.from(elem.querySelectorAll('label'));
+    let pendingInput: string | null = null;
+
+    for (const label of labels) {
+      const labelText = label.textContent?.trim().toLowerCase() ?? '';
+      const container = label.parentElement;
+      if (!container) continue;
+
+     // value is inside nested div → pick the deepest one
+      const wrapperDiv = Array.from(container.children).find(
+        child => child.tagName === 'DIV',
+      ) as HTMLElement | undefined;
+
+if (!wrapperDiv) continue;
+
+// get ALL inner divs and pick the deepest/last one
+const innerDivs = wrapperDiv.querySelectorAll('div');
+const valueDiv = innerDivs.length > 0
+  ? innerDivs[innerDivs.length - 1]
+  : wrapperDiv;
+
+const value = valueDiv.textContent?.trim() ?? '';
+      // Skip placeholder text that AlgoZenith shows before output is revealed.
+      if (value.startsWith('Click on Run on Sample')) continue;
+      if (value.length === 0) continue;
+
+      if (labelText.includes('input')) {
+        pendingInput = value;
+      } else if (labelText.includes('desired output')) {
+        // use only "Desired Output" (skip user's output)
+        if (pendingInput !== null) {
+          task.addTest(pendingInput, value);
+          pendingInput = null;
+        }
+      }
+    }
+
+    if (task.tests.length === 0) {
+      console.warn('AlgoZenith parser: No test cases found');
     }
 
     return task.build();


### PR DESCRIPTION

Fixes parsing for AlgoZenith (maang.in) problems.

- Replaces fragile DOM selectors with label-based parsing
- Uses "Desired Output" instead of user output
- Skips placeholder output text
- Handles nested div structure in React UI
- Supports multiple test cases

Tested on:
https://maang.in/problems/Say-Hello-With-C-1133

AlgoZenith uses a tab-based UI where only the active test case is present in the DOM. Because of this, the parser can only extract one test case at a time.

Users can switch tabs and run the extension again to import additional test cases.

<img width="921" height="416" alt="image" src="https://github.com/user-attachments/assets/d9cf6129-ea98-4f22-92d0-035cd6689e2f" />

<br/>

<img width="1115" height="531" alt="image" src="https://github.com/user-attachments/assets/968a1c02-526a-4048-8d6c-9fa90efee3c1" />

