### PR TITLE
Fix PTA parser

### DIFF
--- a/src/parsers/problem/PTAProblemParser.ts
+++ b/src/parsers/problem/PTAProblemParser.ts
@@ -12,38 +12,196 @@ export class PTAProblemParser extends Parser {
     const elem = htmlToElement(html);
     const task = new TaskBuilder('PTA').setUrl(url);
 
-    const container = elem.querySelector('.scroll');
+    const problemPanel = elem.querySelector('#exam-app .left_rtQmv, #exam-app .splitArea_DF4tO .left_rtQmv');
+    const titleElement = problemPanel?.querySelector(
+      [
+        'span.text-darkest.font-bold.text-lg',
+        '.text-darkest.font-bold.text-lg',
+        '.p-4 .font-bold.text-lg',
+      ].join(', '),
+    );
+    if (titleElement === null) {
+      throw new Error('Could not determine the PTA problem title');
+    }
 
-    task.setName(container.querySelector('.text-darkest.font-bold.text-lg')!.textContent!.trim());
-    const categoryEl = elem.querySelector('.fixed.top-0.w-full .text-lg.ellipsis');
-    task.setCategory(categoryEl ? categoryEl.textContent!.trim() : '');
+    task.setName(titleElement.textContent.trim());
 
-    const limits = [...elem.querySelectorAll('.problemInfo_tfBoz .pc-text-raw')].map(l => l.textContent || '');
+    const categoryElement = elem.querySelector(
+      [
+        '#PROGRAMMING .text-sm.font-black',
+        '#exam-app a.active-anchor .text-sm.font-black',
+        '#exam-app a.active .text-sm.font-black',
+      ].join(', '),
+    );
+    task.setCategory(categoryElement?.textContent?.trim() || '');
 
-    const timeLimitStr = limits.find(text => text.includes('ms'));
-    const memoryLimitStr = limits.find(text => text.includes('MB'));
+    const limitations = this.parseLimitations(elem);
+    if (limitations.timeLimit !== null) {
+      task.setTimeLimit(limitations.timeLimit);
+    }
+    if (limitations.memoryLimit !== null) {
+      task.setMemoryLimit(limitations.memoryLimit);
+    }
 
-    task.setTimeLimit(parseInt(/(\d+)/.exec(timeLimitStr)[1], 10));
-    task.setMemoryLimit(parseInt(/(\d+)/.exec(memoryLimitStr)[1], 10));
+    const samples = this.parseSamples(elem);
+    const fallbackSamples = samples.length > 0 ? samples : this.parseSamplesFromLanguageBlocks(elem);
 
-    const inputHeader = elem.querySelector('h3[id*="输入样例"]');
-    const outputHeader = elem.querySelector('h3[id*="输出样例"]');
-
-    if (inputHeader && outputHeader) {
-      const inputCode = inputHeader.nextElementSibling?.querySelector('code')?.textContent?.trim();
-      const outputCode = outputHeader.nextElementSibling?.querySelector('code')?.textContent?.trim();
-
-      if (inputCode && outputCode) {
-        task.addTest(inputCode, outputCode);
+    if (fallbackSamples.length > 0) {
+      for (const sample of fallbackSamples) {
+        task.addTest(sample.input, sample.output);
       }
     } else {
-      const blocks = [...elem.querySelectorAll('.rendered-markdown pre > code:not(.hljs)')];
+      const blocks = [...elem.querySelectorAll('.rendered-markdown pre > code:not(.hljs), .rendered-markdown > pre')];
 
       for (let i = 0; i < blocks.length - 1; i += 2) {
-        task.addTest(blocks[i].textContent, blocks[i + 1].textContent);
+        task.addTest(blocks[i].textContent || '', blocks[i + 1].textContent || '');
       }
     }
 
+    if (task.tests.length === 0) {
+      throw new Error('Could not extract any PTA sample tests');
+    }
+
     return task.build();
+  }
+
+  private parseLimitations(elem: Element): { timeLimit: number | null; memoryLimit: number | null } {
+    let timeLimit: number | null = null;
+    let memoryLimit: number | null = null;
+
+    for (const item of elem.querySelectorAll('.problemInfo_HVczC .item_YVmJd, [class*="problemInfo"] .item_YVmJd')) {
+      const texts = [...item.querySelectorAll('.pc-text-raw')]
+        .map(node => node.textContent?.trim() || '')
+        .filter(Boolean);
+
+      if (texts.length < 2) {
+        continue;
+      }
+
+      const [label, value] = texts;
+
+      if (label === 'Time Limit') {
+        const match = value.match(/(\d+)/);
+        if (match !== null) {
+          timeLimit = parseInt(match[1], 10);
+        }
+      } else if (label === 'Memory Limit') {
+        const match = value.match(/(\d+)/);
+        if (match !== null) {
+          memoryLimit = parseInt(match[1], 10);
+        }
+      }
+    }
+
+    return { timeLimit, memoryLimit };
+  }
+
+  private parseSamples(elem: Element): { input: string; output: string }[] {
+    const sampleMap = new Map<number, { input?: string; output?: string }>();
+    let nextUnnamedIndex = 1;
+
+    for (const header of elem.querySelectorAll('h3')) {
+      const sampleInfo = this.parseSampleHeader(header.textContent || '');
+      if (sampleInfo === null) {
+        continue;
+      }
+
+      const text = this.extractSectionCodeBlocks(header, sampleInfo.kind === 'input' ? ['in'] : ['out']);
+      if (text.length === 0) {
+        continue;
+      }
+
+      const index = sampleInfo.index ?? nextUnnamedIndex++;
+      const sample = sampleMap.get(index) || {};
+      sample[sampleInfo.kind] = text.join('\n');
+      sampleMap.set(index, sample);
+    }
+
+    return [...sampleMap.entries()]
+      .sort(([left], [right]) => left - right)
+      .map(([, sample]) => sample)
+      .filter((sample): sample is { input: string; output: string } => !!sample.input && !!sample.output);
+  }
+
+  private parseSamplesFromLanguageBlocks(elem: Element): { input: string; output: string }[] {
+    const samples: { input: string; output: string }[] = [];
+    let pendingInput: string | null = null;
+
+    for (const block of elem.querySelectorAll('[data-lang="in"], [data-lang="out"]')) {
+      const lang = block.getAttribute('data-lang');
+      const text = this.extractCodeBlockText(block);
+      if (text === null) {
+        continue;
+      }
+
+      if (lang === 'in') {
+        pendingInput = text;
+      } else if (lang === 'out' && pendingInput !== null) {
+        samples.push({
+          input: pendingInput,
+          output: text,
+        });
+        pendingInput = null;
+      }
+    }
+
+    return samples;
+  }
+
+  private parseSampleHeader(text: string): { kind: 'input' | 'output'; index: number | null } | null {
+    const normalized = text.trim();
+    const inputMatch = normalized.match(/(?:输入样例|Sample Input)\s*(\d+)?/i);
+    if (inputMatch !== null) {
+      return {
+        kind: 'input',
+        index: inputMatch[1] ? parseInt(inputMatch[1], 10) : null,
+      };
+    }
+
+    const outputMatch = normalized.match(/(?:输出样例|Sample Output)\s*(\d+)?/i);
+    if (outputMatch !== null) {
+      return {
+        kind: 'output',
+        index: outputMatch[1] ? parseInt(outputMatch[1], 10) : null,
+      };
+    }
+
+    return null;
+  }
+
+  private extractSectionCodeBlocks(header: Element, langs: string[]): string[] {
+    const blocks: string[] = [];
+    let element = header.nextElementSibling;
+
+    while (element !== null && element.tagName !== 'H3') {
+      const lang = element.getAttribute('data-lang');
+      const text = this.extractCodeBlockText(element);
+
+      if (text !== null && (langs.length === 0 || lang === null || langs.includes(lang))) {
+        blocks.push(text);
+      }
+
+      element = element.nextElementSibling;
+    }
+
+    return blocks;
+  }
+
+  private extractCodeBlockText(block: Element): string | null {
+    const lineElements = block.querySelectorAll('.cm-content .cm-line');
+    if (lineElements.length > 0) {
+      return [...lineElements].map(line => line.textContent || '').join('\n');
+    }
+
+    const codeElement = block.querySelector('code');
+    if (codeElement !== null) {
+      return codeElement.textContent || '';
+    }
+
+    if (block.matches('pre')) {
+      return block.textContent || '';
+    }
+
+    return null;
   }
 }


### PR DESCRIPTION
## Summary

This PR improves the PTA (`pintia.cn`) problem parser to be more robust and support multiple sample test cases.

The `PTAProblemParser` has been refactored to handle various page layouts, including support for both single and multiple named sample inputs/outputs (e.g., "Sample Input 1", "Sample Input 2").

## What changed

- **Refactored `PTAProblemParser`**: Replaced simple selector-based parsing with a more comprehensive DOM traversal logic.
- **Improved Metadata Extraction**:
  - Enhanced title and category detection using multiple fallback selectors to support different PTA page versions/layouts.
  - Introduced `parseLimitations` to accurately extract time and memory limits from the problem info panel.
- **Advanced Sample Parsing**:
  - Added `parseSamples`: Detects sample blocks by scanning headers (`h3`) for "输入样例", "Sample Input", etc.
  - Added `parseSamplesFromLanguageBlocks`: Fallback for cases where samples are identified by `data-lang` attributes.
  - Added `extractSectionCodeBlocks`: Handles nested code elements and `cm-line` classes used in PTA's editor/viewer.
- **Bug Fixes**:
  - Fixed issues where only the first sample test was parsed.
  - Added support for multi-point test cases by pairing input/output based on their sample index.

## Implementation details

- **Title/Category**: Now uses a prioritized list of selectors to find the problem name and category (e.g., searching within `#exam-app` or specific font-bold classes).
- **Limit Extraction**: Scans `.problemInfo_HVczC` and related classes, regex-matching digits for "Time Limit" and "Memory Limit".
- **Sample Logic**: 
  - The parser now maintains a `sampleMap` to pair inputs and outputs correctly even if they are interspersed with other content.
  - It supports extracting text from both standard `<code>` tags and the CodeMirror-based `.cm-content .cm-line` structure.

## Notes

- This update significantly improves the success rate of parsing complex or older problems on PTA.
- It maintains backward compatibility with the unified `TaskBuilder` format.

## Tested

- Tested on standard PTA programming problems.
- Verified correct pairing for problems with multiple sample test cases (e.g., "Sample Input 1" paired with "Sample Output 1").
- Verified that time and memory limits are correctly parsed and converted to integers.