### PR TITLE
Preserve digits in Meta Coding Competitions filename pattern

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## Unreleased
+- Fix the Meta Coding Competitions parser preserving digits in input/output filename patterns
+
 ## [2.65.0](https://github.com/jmerle/competitive-companion/releases/tag/2.65.0) (2026-06-29)
 - Add support for Wincent DragonByte (thanks [@EgorKulikov](https://github.com/EgorKulikov))
 - Fix the Luogu problem parser reading the lower bound of a per-testdata time-limit range (e.g. "500ms ~ 3.00s" was treated as 500s instead of 3s) and set the contest name as the group when parsing contest-scoped problem URLs (thanks [@EgorKulikov](https://github.com/EgorKulikov))

--- a/src/parsers/problem/MetaCodingCompetitionsProblemParser.ts
+++ b/src/parsers/problem/MetaCodingCompetitionsProblemParser.ts
@@ -31,7 +31,7 @@ export class MetaCodingCompetitionsProblemParser extends Parser {
     const filename = nameWithoutPrefix
       .toLowerCase()
       .replace(/[^a-zA-Z0-9 ]/g, '')
-      .replace(/[^a-zA-Z]+/g, '_');
+      .replace(/[^a-zA-Z0-9]+/g, '_');
 
     task.setInput({
       pattern: `${filename}_.*input[.]txt`,

--- a/tests/data/meta-coding-competitions/problem/normal.json
+++ b/tests/data/meta-coding-competitions/problem/normal.json
@@ -18,11 +18,11 @@
     "testType": "multiNumber",
     "input": {
       "type": "regex",
-      "pattern": "leapfrog_ch__.*input[.]txt"
+      "pattern": "leapfrog_ch_1_.*input[.]txt"
     },
     "output": {
       "type": "file",
-      "fileName": "leapfrog_ch__output.txt"
+      "fileName": "leapfrog_ch_1_output.txt"
     },
     "languages": {
       "java": {


### PR DESCRIPTION
## Summary
- The Meta Coding Competitions parser stripped digits when building the input/output filename pattern, because the second `replace` matched `[^a-zA-Z]+` (which includes digits).
- For Hacker Cup 2025 Round 1 Problem A1 (`Snake Scales, Chapter 1`), the parser produced `snake_scales_chapter__.*input[.]txt`, but the real file is `snake_scales_chapter_1_input.txt`.
- Switched the second replace to `[^a-zA-Z0-9]+` so digits survive, and updated the existing 2019 Leapfrog test to reflect the corrected pattern.

Fixes #666

## Test plan
- [x] `pnpm lint:eslint`
- [x] `pnpm lint:tsc`
- [x] `pnpm lint:prettier`
- [x] `pnpm test -t meta-coding-competitions`