### PR TITLE
Fix CodeRun parser on redesigned problem page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## Unreleased
+- Fix the CodeRun parser on the redesigned problem page layout and support seasons/tracks URLs
+
 ## [2.65.0](https://github.com/jmerle/competitive-companion/releases/tag/2.65.0) (2026-06-29)
 - Add support for Wincent DragonByte (thanks [@EgorKulikov](https://github.com/EgorKulikov))
 - Fix the Luogu problem parser reading the lower bound of a per-testdata time-limit range (e.g. "500ms ~ 3.00s" was treated as 500s instead of 3s) and set the contest name as the group when parsing contest-scoped problem URLs (thanks [@EgorKulikov](https://github.com/EgorKulikov))

--- a/src/parsers/problem/CodeRunProblemParser.ts
+++ b/src/parsers/problem/CodeRunProblemParser.ts
@@ -5,7 +5,11 @@ import { Parser } from '../Parser';
 
 export class CodeRunProblemParser extends Parser {
   public getMatchPatterns(): string[] {
-    return ['https://coderun.yandex.ru/problem/*', 'https://coderun.yandex.ru/*/problems/*'];
+    return [
+      'https://coderun.yandex.ru/problem/*',
+      'https://coderun.yandex.ru/*/problems/*',
+      'https://coderun.yandex.ru/*/problem/*',
+    ];
   }
 
   public async parse(url: string, html: string): Promise<Sendable> {
@@ -14,9 +18,10 @@ export class CodeRunProblemParser extends Parser {
 
     task.setName(elem.querySelector('h1').textContent);
 
-    const limitsElems = elem.querySelectorAll('dl[class^="Description_description-runtime-limits"] > dd > p');
-    task.setTimeLimit(parseInt(limitsElems[0].textContent.split(' ')[0]) * 1000);
-    task.setMemoryLimit(parseInt(limitsElems[1].textContent.split(' ')[0]));
+    const limitsElems = elem.querySelectorAll('dl[class^="Description_description-runtime-limits"] > dd');
+    const [timeValue, timeUnit] = limitsElems[0].textContent.trim().split(/\s+/);
+    task.setTimeLimit(parseInt(timeValue) * (timeUnit === 'мс' ? 1 : 1000));
+    task.setMemoryLimit(parseInt(limitsElems[1].textContent.trim().split(/\s+/)[0]));
 
     elem.querySelectorAll('.io-sample').forEach(sampleElem => {
       const input = sampleElem.querySelector('.input-snippet code').textContent;

--- a/tests/before-functions.ts
+++ b/tests/before-functions.ts
@@ -25,6 +25,10 @@ export const beforeFunctions: { [name: string]: (page: Page) => Promise<void> } 
     await page.waitForSelector('main .container .v-sheet > .row:last-child');
   },
 
+  async beforeCodeRun(page: Page): Promise<void> {
+    await page.waitForSelector('.io-sample .input-snippet code');
+  },
+
   async beforeCOJContest(page: Page): Promise<void> {
     await page.waitForSelector('#problem td > a');
   },

--- a/tests/data/coderun/problem/normal.json
+++ b/tests/data/coderun/problem/normal.json
@@ -1,0 +1,40 @@
+{
+  "url": "https://coderun.yandex.ru/seasons/2025-winter/tracks/common/problem/thermal-panels",
+  "parser": "CodeRunProblemParser",
+  "before": "beforeCodeRun",
+  "result": {
+    "name": "726. Тепловые панели",
+    "group": "CodeRun",
+    "url": "https://coderun.yandex.ru/problem/thermal-panels",
+    "interactive": false,
+    "memoryLimit": 512,
+    "timeLimit": 300,
+    "tests": [
+      {
+        "input": "8 1\n",
+        "output": "3 3\n"
+      },
+      {
+        "input": "10 2\n",
+        "output": "4 3\n"
+      },
+      {
+        "input": "24 24\n",
+        "output": "8 6\n"
+      }
+    ],
+    "testType": "single",
+    "input": {
+      "type": "stdin"
+    },
+    "output": {
+      "type": "stdout"
+    },
+    "languages": {
+      "java": {
+        "mainClass": "Main",
+        "taskClass": "TeploviePaneli"
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- CodeRun's problem pages now show time/memory limits in `<dd>` elements directly, without an inner `<p>`, so the previous `dl > dd > p` selector returned no elements and the parser crashed.
- Problem URLs are also reachable at `https://coderun.yandex.ru/seasons/<season>/tracks/<track>/problem/<name>`. That URL is server-redirected to `/problem/<name>`, but the original is what shows up in the address bar when the user navigates, so the match pattern needs to cover it.
- The time limit unit is now either `X с` (seconds) or `X мс` (milliseconds) depending on the value, so the parser must look at the unit before converting to ms.

This PR addresses all three: the limits selector drops `> p`, a new `https://coderun.yandex.ru/*/problem/*` pattern is added, and the time-limit conversion is unit-aware. Added a problem fixture for the issue's example URL.

Fixes #669

## Test plan
- [x] `pnpm lint:eslint`
- [x] `pnpm lint:tsc`
- [x] `pnpm lint:prettier`
- [x] `pnpm test -t coderun`