### PR TITLE
Add parser for the new Yandex.Contest interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## Unreleased
+- Add support for the new Yandex.Contest interface (new.contest.yandex.ru)
+
 ## [2.65.0](https://github.com/jmerle/competitive-companion/releases/tag/2.65.0) (2026-06-29)
 - Add support for Wincent DragonByte (thanks [@EgorKulikov](https://github.com/EgorKulikov))
 - Fix the Luogu problem parser reading the lower bound of a per-testdata time-limit range (e.g. "500ms ~ 3.00s" was treated as 500s instead of 3s) and set the contest name as the group when parsing contest-scoped problem URLs (thanks [@EgorKulikov](https://github.com/EgorKulikov))

--- a/src/parsers/parsers.ts
+++ b/src/parsers/parsers.ts
@@ -158,6 +158,7 @@ import { WincentDragonByteProblemParser } from './problem/WincentDragonByteProbl
 import { XCampProblemParser } from './problem/XCampProblemParser';
 import { XXMProblemParser } from './problem/XXMProblemParser';
 import { YACSProblemParser } from './problem/YACSProblemParser';
+import { YandexNewProblemParser } from './problem/YandexNewProblemParser';
 import { YandexProblemParser } from './problem/YandexProblemParser';
 import { YukicoderProblemParser } from './problem/YukicoderProblemParser';
 import { ZOJProblemParser } from './problem/ZOJProblemParser';
@@ -420,6 +421,7 @@ export const parsers: Parser[] = [
 
   new YandexProblemParser(),
   new YandexContestParser(),
+  new YandexNewProblemParser(),
 
   new YACSProblemParser(),
 

--- a/src/parsers/problem/YandexNewProblemParser.ts
+++ b/src/parsers/problem/YandexNewProblemParser.ts
@@ -1,0 +1,46 @@
+import { Sendable } from '../../models/Sendable';
+import { TaskBuilder } from '../../models/TaskBuilder';
+import { htmlToElement } from '../../utils/dom';
+import { Parser } from '../Parser';
+
+export class YandexNewProblemParser extends Parser {
+  public getMatchPatterns(): string[] {
+    return ['https://new.contest.yandex.ru/contests/*/problems*'];
+  }
+
+  public async parse(url: string, html: string): Promise<Sendable> {
+    const elem = htmlToElement(html);
+    const task = new TaskBuilder('Yandex').setUrl(url);
+
+    task.setName(elem.querySelector('h1[class*="Problem_Problem-Header"]').textContent);
+
+    const contestTitleElem = elem.querySelector('[class*="ContestMenu_ContestMenu-Title"] p[title]');
+    if (contestTitleElem !== null) {
+      task.setCategory(contestTitleElem.getAttribute('title') ?? contestTitleElem.textContent);
+    }
+
+    const timeLimitElem = elem.querySelector('tr[data-testid="time-limit"] td:last-child');
+    if (timeLimitElem !== null) {
+      const [valueStr, unit] = timeLimitElem.textContent.trim().split(/\s+/);
+      const seconds = unit?.toLowerCase().startsWith('ms') ? parseFloat(valueStr) / 1000 : parseFloat(valueStr);
+      task.setTimeLimit(Math.round(seconds * 1000));
+    }
+
+    const memoryLimitElem = elem.querySelector('tr[data-testid="memory-limit"] td:last-child');
+    if (memoryLimitElem !== null) {
+      const [valueStr, unit] = memoryLimitElem.textContent.trim().split(/\s+/);
+      const value = parseFloat(valueStr);
+      const mb = unit?.toLowerCase().startsWith('g') ? value * 1024 : value;
+      task.setMemoryLimit(Math.round(mb));
+    }
+
+    elem.querySelectorAll('[class*="StatementSample_StatementSample-Content"]').forEach(sampleElem => {
+      const blocks = sampleElem.querySelectorAll('pre code');
+      if (blocks.length >= 2) {
+        task.addTest(blocks[0].textContent, blocks[1].textContent);
+      }
+    });
+
+    return task.build();
+  }
+}


### PR DESCRIPTION
## Summary
- Yandex.Contest's new interface lives at `new.contest.yandex.ru` (Next.js, server-rendered) and shares nothing with the old DOM — different class names, CSS-module hashes, and sample/limit layouts. The existing `YandexProblemParser` doesn't match these URLs and wouldn't find the content if it did.
- Added `YandexNewProblemParser` targeting `https://new.contest.yandex.ru/contests/*/problems*`. It uses stable `data-testid` attributes for time/memory limit cells and substring matches against the CSS-module class prefixes (the hash suffixes change every build) for the problem title, contest title, and sample blocks.
- Time-limit parsing handles both `1 s` and `... ms` units; memory parses `... Mb` and `... Gb`.

The old `YandexProblemParser` (`contest.yandex.com`) is untouched.

Fixes #654

## Testing
The new interface requires Yandex authentication, and pages don't load without an authenticated session. No automated fixture was added (the existing Yandex parser also has none, for the same reason). Verified manually against a saved problem page from the public demo contest: parser produces correct name, group, 1 s time limit, 64 MB memory limit, and sample input/output.

## Test plan
- [x] `pnpm lint:eslint`
- [x] `pnpm lint:tsc`
- [x] `pnpm lint:prettier`
- [x] Maintainer to verify against a live new-interface contest