### PR TITLE
Update KEP.uz problem parser for the redesigned interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## Unreleased
+- Fix the KEP.uz problem parser for the redesigned interface
+
 ## [2.65.0](https://github.com/jmerle/competitive-companion/releases/tag/2.65.0) (2026-06-29)
 - Add support for Wincent DragonByte (thanks [@EgorKulikov](https://github.com/EgorKulikov))
 - Fix the Luogu problem parser reading the lower bound of a per-testdata time-limit range (e.g. "500ms ~ 3.00s" was treated as 500s instead of 3s) and set the contest name as the group when parsing contest-scoped problem URLs (thanks [@EgorKulikov](https://github.com/EgorKulikov))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 - Fix the KEP.uz problem parser for the redesigned interface
+- Fix the KEP.uz contest parser after the contests URL scheme moved from `/competitions/contests/contest/<id>/problems` to `/contests/<id>/problems`
 
 ## [2.65.0](https://github.com/jmerle/competitive-companion/releases/tag/2.65.0) (2026-06-29)
 - Add support for Wincent DragonByte (thanks [@EgorKulikov](https://github.com/EgorKulikov))

--- a/src/parsers/contest/KEPUZContestParser.ts
+++ b/src/parsers/contest/KEPUZContestParser.ts
@@ -11,7 +11,7 @@ interface ProblemDescription {
 
 export class KEPUZContestParser extends ContestParser<ProblemDescription> {
   public getMatchPatterns(): string[] {
-    return ['https://kep.uz/competitions/contests/contest/*/problems'];
+    return ['https://kep.uz/contests/*/problems'];
   }
 
   protected async getTasksToParse(html: string, url: string): Promise<ProblemDescription[]> {
@@ -20,7 +20,9 @@ export class KEPUZContestParser extends ContestParser<ProblemDescription> {
     const urlParts = url.split('/');
     const contestId = urlParts[urlParts.length - 2];
 
-    const linkElems = [...elem.querySelectorAll<HTMLAnchorElement>('td > a[href^="/competitions/contests/contest/"]')];
+    const linkElems = [
+      ...elem.querySelectorAll<HTMLAnchorElement>('a[href^="/contests/"][href*="/problem/"]'),
+    ];
     return linkElems.map(linkElem => ({
       contestId,
       problemSymbol: linkElem.href.split('/').pop(),
@@ -28,7 +30,7 @@ export class KEPUZContestParser extends ContestParser<ProblemDescription> {
   }
 
   protected async parseTask(problem: ProblemDescription): Promise<Task> {
-    const url = `https://kep.uz/competitions/contests/contest/${problem.contestId}/problem/${problem.problemSymbol}`;
+    const url = `https://kep.uz/contests/${problem.contestId}/problem/${problem.problemSymbol}`;
     const task = new TaskBuilder('KEP.uz').setUrl(url);
 
     const body = await request(

--- a/src/parsers/problem/KEPUZProblemParser.ts
+++ b/src/parsers/problem/KEPUZProblemParser.ts
@@ -5,24 +5,42 @@ import { Parser } from '../Parser';
 
 export class KEPUZProblemParser extends Parser {
   public getMatchPatterns(): string[] {
-    return ['https://kep.uz/practice/problems/problem/*', 'https://kep.uz/competitions/contests/contest/*/problem/*'];
+    return ['https://kep.uz/problems/*', 'https://kep.uz/contests/*/problem/*'];
   }
 
   public async parse(url: string, html: string): Promise<Sendable> {
     const elem = htmlToElement(html);
     const task = new TaskBuilder('KEP.uz').setUrl(url);
 
-    const containerElem = elem.querySelector('problem-body').parentElement;
+    task.setName(elem.querySelector('h5').textContent.trim());
 
-    task.setName(containerElem.querySelector('.problem-title > h3, h2').textContent.trim());
+    for (const chip of elem.querySelectorAll('.MuiChip-label')) {
+      const text = chip.textContent.trim();
+      const timeMatch = text.match(/Time limit:\s*(\d+)\s*ms/i);
+      if (timeMatch !== null) {
+        task.setTimeLimit(parseInt(timeMatch[1], 10));
+        continue;
+      }
+      const memoryMatch = text.match(/Memory limit:\s*(\d+)\s*MB/i);
+      if (memoryMatch !== null) {
+        task.setMemoryLimit(parseInt(memoryMatch[1], 10));
+      }
+    }
 
-    task.setTimeLimit(parseInt(elem.querySelector('.limits .bg-info').textContent.trim().split(' ')[0]));
-    task.setMemoryLimit(parseInt(elem.querySelector('.limits .bg-primary').textContent.trim().split(' ')[0]));
-
-    containerElem.querySelectorAll('.sample-test').forEach(tableElem => {
-      const blocks = tableElem.querySelectorAll('pre');
-      task.addTest(blocks[0].innerHTML, blocks[1].innerHTML);
-    });
+    const sampleHeader = [...elem.querySelectorAll('h6')].find(h => /Sample tests/i.test(h.textContent));
+    if (sampleHeader !== undefined) {
+      const samplesContainer = sampleHeader.nextElementSibling;
+      if (samplesContainer !== null) {
+        for (const card of samplesContainer.querySelectorAll(':scope > [class*="MuiPaper"]')) {
+          const textBlocks = [...card.querySelectorAll('div[class*="MuiBox"]')].filter(
+            box => box.children.length === 0,
+          );
+          if (textBlocks.length >= 2) {
+            task.addTest(textBlocks[0].textContent, textBlocks[1].textContent);
+          }
+        }
+      }
+    }
 
     return task.build();
   }

--- a/tests/before-functions.ts
+++ b/tests/before-functions.ts
@@ -57,6 +57,12 @@ export const beforeFunctions: { [name: string]: (page: Page) => Promise<void> } 
     await page.waitForSelector('.problem-io-wrapper pre.io-content, .problem-io-wrapper-new pre.sample-content-text');
   },
 
+  async beforeKEPUZ(page: Page): Promise<void> {
+    await page.waitForFunction(
+      "document.querySelectorAll('.MuiChip-label').length > 0 && [...document.querySelectorAll('h6')].some(h => /Sample tests/i.test(h.textContent))",
+    );
+  },
+
   async beforeLibraryChecker(page: Page): Promise<void> {
     await page.waitForSelector('.MuiContainer-root.MuiContainer-maxWidthLg .MuiTypography-h2');
   },

--- a/tests/data/kep-uz/problem/normal.json
+++ b/tests/data/kep-uz/problem/normal.json
@@ -1,0 +1,36 @@
+{
+  "url": "https://kep.uz/problems/1",
+  "parser": "KEPUZProblemParser",
+  "before": "beforeKEPUZ",
+  "result": {
+    "name": "1. Sum of Two Numbers",
+    "group": "KEP.uz",
+    "url": "https://kep.uz/problems/1",
+    "interactive": false,
+    "memoryLimit": 512,
+    "timeLimit": 3000,
+    "tests": [
+      {
+        "input": "2\n2\n",
+        "output": "4\n"
+      },
+      {
+        "input": "5\n10\n",
+        "output": "15\n"
+      }
+    ],
+    "testType": "single",
+    "input": {
+      "type": "stdin"
+    },
+    "output": {
+      "type": "stdout"
+    },
+    "languages": {
+      "java": {
+        "mainClass": "Main",
+        "taskClass": "SumOfTwoNumbers"
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- KEP.uz rebuilt its problem pages on Material UI. The previous selectors no longer match anything:
  - Problem title moved from `.problem-title > h3, h2` to a plain `<h5>`.
  - Time/memory limits moved out of `.limits .bg-info`/`.bg-primary` into `.MuiChip-label` chips that read `"Time limit: 3000 ms"` and `"Memory limit: 512 MB"`.
  - Sample tests moved from `.sample-test` tables to cards under an `<h6>` titled "Sample tests"; the input/output values now live in plain `MuiBox` divs (no `<pre>`).
- URL paths also changed: `/practice/problems/problem/*` redirects to `/problems/*`, and `/competitions/contests/contest/*/problem/*` redirects to `/contests/*/problem/*`. Updated match patterns to the new paths.
- Added a problem fixture for `https://kep.uz/problems/1` ("Sum of Two Numbers").

Fixes #665

## Test plan
- [x] \`pnpm lint:eslint\`
- [x] \`pnpm lint:tsc\`
- [x] \`pnpm lint:prettier\`
- [x] \`pnpm test -t kep-uz\`