### PR TITLE
Add problem parser for EldarVerse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## Unreleased
+- Add support for EldarVerse
+
 ## [2.65.0](https://github.com/jmerle/competitive-companion/releases/tag/2.65.0) (2026-06-29)
 - Add support for Wincent DragonByte (thanks [@EgorKulikov](https://github.com/EgorKulikov))
 - Fix the Luogu problem parser reading the lower bound of a per-testdata time-limit range (e.g. "500ms ~ 3.00s" was treated as 500s instead of 3s) and set the contest name as the group when parsing contest-scoped problem URLs (thanks [@EgorKulikov](https://github.com/EgorKulikov))

--- a/src/parsers/parsers.ts
+++ b/src/parsers/parsers.ts
@@ -86,6 +86,7 @@ import { DimikOJProblemParser } from './problem/DimikOJProblemParser';
 import { DMOJProblemParser } from './problem/DMOJProblemParser';
 import { DotOJProblemParser } from './problem/DotOJProblemParser';
 import { ECNUOnlineJudgeProblemParser } from './problem/ECNUOnlineJudgeProblemParser';
+import { EldarVerseProblemParser } from './problem/EldarVerseProblemParser';
 import { EolympBasecampProblemParser } from './problem/EolympBasecampProblemParser';
 import { FZUOnlineJudgeProblemParser } from './problem/FZUOnlineJudgeProblemParser';
 import { GoogleCodingCompetitionsProblemParser } from './problem/GoogleCodingCompetitionsProblemParser';
@@ -248,6 +249,8 @@ export const parsers: Parser[] = [
 
   new ECNUOnlineJudgeProblemParser(),
   new ECNUOnlineJudgeContestParser(),
+
+  new EldarVerseProblemParser(),
 
   new EolympBasecampProblemParser(),
   new EolympBasecampContestParser(),

--- a/src/parsers/problem/EldarVerseProblemParser.ts
+++ b/src/parsers/problem/EldarVerseProblemParser.ts
@@ -1,0 +1,34 @@
+import { Sendable } from '../../models/Sendable';
+import { TaskBuilder } from '../../models/TaskBuilder';
+import { htmlToElement } from '../../utils/dom';
+import { Parser } from '../Parser';
+
+export class EldarVerseProblemParser extends Parser {
+  public getMatchPatterns(): string[] {
+    return ['https://www.eldarverse.com/problem/*', 'https://eldarverse.com/problem/*'];
+  }
+
+  public async parse(url: string, html: string): Promise<Sendable> {
+    const elem = htmlToElement(html);
+    const task = new TaskBuilder('EldarVerse').setUrl(url);
+
+    const problemContent = elem.querySelector('.problem-content');
+    if (problemContent === null) {
+      throw new Error('Could not find .problem-content on EldarVerse problem page');
+    }
+
+    task.setName(problemContent.querySelector('h1').textContent.trim());
+
+    const contestLink = elem.querySelector('a[href^="/contest/"]');
+    if (contestLink !== null) {
+      task.setCategory(contestLink.textContent.trim());
+    }
+
+    const blocks = problemContent.querySelectorAll('pre code');
+    for (let i = 0; i + 1 < blocks.length; i += 2) {
+      task.addTest(blocks[i].textContent, blocks[i + 1].textContent);
+    }
+
+    return task.build();
+  }
+}

--- a/tests/data/eldarverse/problem/normal.json
+++ b/tests/data/eldarverse/problem/normal.json
@@ -1,0 +1,31 @@
+{
+  "url": "https://www.eldarverse.com/problem/halloween25-1A",
+  "parser": "EldarVerseProblemParser",
+  "result": {
+    "name": "Werewolf Clans",
+    "group": "EldarVerse - October 2025 Long Challenge - Halloween",
+    "url": "https://www.eldarverse.com/problem/halloween25-1A",
+    "interactive": false,
+    "memoryLimit": 1024,
+    "timeLimit": 1000,
+    "tests": [
+      {
+        "input": "4\n7 158\n10 777\n12 012345\n1 235\n",
+        "output": "Case #1: 3 2\nCase #2: 10 10\nCase #3: 2 2\nCase #4: 1 0\n"
+      }
+    ],
+    "testType": "single",
+    "input": {
+      "type": "stdin"
+    },
+    "output": {
+      "type": "stdout"
+    },
+    "languages": {
+      "java": {
+        "mainClass": "Main",
+        "taskClass": "WerewolfClans"
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- New problem parser for [EldarVerse](https://www.eldarverse.com/), matching `https://www.eldarverse.com/problem/*` (and the apex domain).
- Pulls the problem title from the `.problem-content > h1`, the contest name from the `a[href^="/contest/"]` link in the metadata block, and sample input/output from the `pre > code` pairs inside `.problem-content`.
- Time/memory limits are not surfaced on the page, so the parser leaves the `TaskBuilder` defaults in place.
- Fixture covers `halloween25-1A` from the October 2025 Long Challenge.

Fixes #656

## Test plan
- [x] `pnpm lint:eslint`
- [x] `pnpm lint:tsc`
- [x] `pnpm lint:prettier`
- [x] `pnpm test -t eldarverse`