### PR TITLE
Use human-readable contest names for CodeChef tasks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## Unreleased
+- Use the human-readable contest name (e.g. "Starters 240") as the CodeChef group instead of the contest code (e.g. "START240A")
+
 ## [2.65.0](https://github.com/jmerle/competitive-companion/releases/tag/2.65.0) (2026-06-29)
 - Add support for Wincent DragonByte (thanks [@EgorKulikov](https://github.com/EgorKulikov))
 - Fix the Luogu problem parser reading the lower bound of a per-testdata time-limit range (e.g. "500ms ~ 3.00s" was treated as 500s instead of 3s) and set the contest name as the group when parsing contest-scoped problem URLs (thanks [@EgorKulikov](https://github.com/EgorKulikov))

--- a/src/parsers/contest/CodeChefContestParser.ts
+++ b/src/parsers/contest/CodeChefContestParser.ts
@@ -5,7 +5,12 @@ import { request } from '../../utils/request';
 import { ContestParser } from '../ContestParser';
 import { CodeChefOldProblemParser } from '../problem/CodeChefOldProblemParser';
 
-export class CodeChefContestParser extends ContestParser<string> {
+interface TaskInput {
+  apiUrl: string;
+  contestName: string;
+}
+
+export class CodeChefContestParser extends ContestParser<TaskInput> {
   public getMatchPatterns(): string[] {
     return ['https://www.codechef.com/*'];
   }
@@ -14,25 +19,38 @@ export class CodeChefContestParser extends ContestParser<string> {
     return document.querySelector('.cc-problem-name a') !== null;
   }
 
-  protected async getTasksToParse(html: string, url: string): Promise<string[]> {
+  protected async getTasksToParse(html: string, url: string): Promise<TaskInput[]> {
     const elem = htmlToElement(html);
-    const contestId = new URL(url).pathname.split('/').pop();
+    const contestCode = new URL(url).pathname.split('/').pop();
+
+    let contestName = contestCode;
+    try {
+      const data = JSON.parse(await request(`https://www.codechef.com/api/contests/${contestCode}`));
+      if (data.status === 'success' && typeof data.name === 'string' && data.name.length > 0) {
+        contestName = data.name;
+      }
+    } catch {
+      // keep contestCode as fallback
+    }
 
     return [...elem.querySelectorAll<HTMLLinkElement>('.cc-problem-name a')].map(el => {
       const problemId = el.href.split('/').pop();
-      return `https://www.codechef.com/api/contests/${contestId}/problems/${problemId}`;
+      return {
+        apiUrl: `https://www.codechef.com/api/contests/${contestCode}/problems/${problemId}`,
+        contestName,
+      };
     });
   }
 
-  protected async parseTask(apiUrl: string): Promise<Task> {
-    const body = await request(apiUrl);
+  protected async parseTask(input: TaskInput): Promise<Task> {
+    const body = await request(input.apiUrl);
     const model = JSON.parse(body);
 
-    const taskUrl = apiUrl.replace('www.codechef.com/api/contests/', 'www.codechef.com/');
+    const taskUrl = input.apiUrl.replace('www.codechef.com/api/contests/', 'www.codechef.com/');
     const task = new TaskBuilder('CodeChef').setUrl(taskUrl);
 
     task.setName(model.problem_name);
-    task.setCategory(model.contest_code);
+    task.setCategory(input.contestName);
 
     task.setInteractive(model.body.includes('This is an interactive problem'));
 

--- a/src/parsers/problem/CodeChefNewProblemParser.ts
+++ b/src/parsers/problem/CodeChefNewProblemParser.ts
@@ -62,12 +62,14 @@ export class CodeChefNewProblemParser extends Parser {
   private async parseCategory(url: string, elem: Element): Promise<string> {
     const contestIdFromPage = elem.querySelector('a[class^="_contest__link_"]');
     if (contestIdFromPage !== null) {
-      return contestIdFromPage.childNodes[0].textContent.trim();
+      const text = contestIdFromPage.childNodes[0].textContent.trim();
+      return (await this.lookupContestName(text)) ?? text;
     }
 
     const contestIdFromUrl = /https:\/\/www\.codechef\.com\/([^/]+)\/problems\/([^/]+)/.exec(url);
     if (contestIdFromUrl !== null) {
-      return contestIdFromUrl[1];
+      const code = contestIdFromUrl[1];
+      return (await this.lookupContestName(code)) ?? code;
     }
 
     const syllabusName = elem.querySelector('div[class^="_syllabusName_"]');
@@ -77,6 +79,26 @@ export class CodeChefNewProblemParser extends Parser {
 
     const problemId = new URL(url).pathname.split('/').pop();
     const response = await request(`https://www.codechef.com/api/contests/PRACTICE/problems/${problemId}`);
-    return JSON.parse(response).intended_contest_code || 'Practice';
+    const code = JSON.parse(response).intended_contest_code;
+    if (!code) {
+      return 'Practice';
+    }
+    return (await this.lookupContestName(code)) ?? code;
+  }
+
+  private async lookupContestName(code: string): Promise<string | null> {
+    if (code === '' || code.toUpperCase() === 'PRACTICE') {
+      return null;
+    }
+    try {
+      const response = await request(`https://www.codechef.com/api/contests/${code}`);
+      const data = JSON.parse(response);
+      if (data.status === 'success' && typeof data.name === 'string' && data.name.length > 0) {
+        return data.name;
+      }
+    } catch {
+      // fall through to null
+    }
+    return null;
   }
 }

--- a/tests/data/codechef/contest/normal.json
+++ b/tests/data/codechef/contest/normal.json
@@ -5,7 +5,7 @@
   "result": [
     {
       "name": "Magic Elements",
-      "group": "CodeChef - LTIME58A",
+      "group": "CodeChef - March Lunchtime 2018 Division 1 (Unrated)",
       "url": "https://www.codechef.com/LTIME58A/problems/ZOZ",
       "interactive": false,
       "memoryLimit": 256,
@@ -32,7 +32,7 @@
     },
     {
       "name": "Three Integers",
-      "group": "CodeChef - LTIME58A",
+      "group": "CodeChef - March Lunchtime 2018 Division 1 (Unrated)",
       "url": "https://www.codechef.com/LTIME58A/problems/AFK",
       "interactive": false,
       "memoryLimit": 256,
@@ -59,7 +59,7 @@
     },
     {
       "name": "Partitions",
-      "group": "CodeChef - LTIME58A",
+      "group": "CodeChef - March Lunchtime 2018 Division 1 (Unrated)",
       "url": "https://www.codechef.com/LTIME58A/problems/ARRP",
       "interactive": false,
       "memoryLimit": 256,
@@ -86,7 +86,7 @@
     },
     {
       "name": "Queries with GCD",
-      "group": "CodeChef - LTIME58A",
+      "group": "CodeChef - March Lunchtime 2018 Division 1 (Unrated)",
       "url": "https://www.codechef.com/LTIME58A/problems/GQR",
       "interactive": false,
       "memoryLimit": 256,
@@ -113,7 +113,7 @@
     },
     {
       "name": "Queries on Tree",
-      "group": "CodeChef - LTIME58A",
+      "group": "CodeChef - March Lunchtime 2018 Division 1 (Unrated)",
       "url": "https://www.codechef.com/LTIME58A/problems/TRS",
       "interactive": false,
       "memoryLimit": 256,
@@ -140,7 +140,7 @@
     },
     {
       "name": "Chef and Friends",
-      "group": "CodeChef - LTIME58A",
+      "group": "CodeChef - March Lunchtime 2018 Division 1 (Unrated)",
       "url": "https://www.codechef.com/LTIME58A/problems/FRK",
       "interactive": false,
       "memoryLimit": 256,

--- a/tests/data/codechef/contest/samples-in-api.json
+++ b/tests/data/codechef/contest/samples-in-api.json
@@ -5,7 +5,7 @@
   "result": [
     {
       "name": "Olympics Ranking",
-      "group": "CodeChef - AUG21B",
+      "group": "CodeChef - August Challenge 2021 Division 2 (Unrated)",
       "url": "https://www.codechef.com/AUG21B/problems/OLYRANK",
       "interactive": false,
       "memoryLimit": 256,
@@ -32,7 +32,7 @@
     },
     {
       "name": "Problem Difficulties",
-      "group": "CodeChef - AUG21B",
+      "group": "CodeChef - August Challenge 2021 Division 2 (Unrated)",
       "url": "https://www.codechef.com/AUG21B/problems/PROBDIFF",
       "interactive": false,
       "memoryLimit": 256,
@@ -59,7 +59,7 @@
     },
     {
       "name": "Chef and Bulb Invention",
-      "group": "CodeChef - AUG21B",
+      "group": "CodeChef - August Challenge 2021 Division 2 (Unrated)",
       "url": "https://www.codechef.com/AUG21B/problems/CHFINVNT",
       "interactive": false,
       "memoryLimit": 256,
@@ -86,7 +86,7 @@
     },
     {
       "name": "Special Triplets",
-      "group": "CodeChef - AUG21B",
+      "group": "CodeChef - August Challenge 2021 Division 2 (Unrated)",
       "url": "https://www.codechef.com/AUG21B/problems/SPCTRIPS",
       "interactive": false,
       "memoryLimit": 256,
@@ -113,7 +113,7 @@
     },
     {
       "name": "Array Filling",
-      "group": "CodeChef - AUG21B",
+      "group": "CodeChef - August Challenge 2021 Division 2 (Unrated)",
       "url": "https://www.codechef.com/AUG21B/problems/ARRFILL",
       "interactive": false,
       "memoryLimit": 256,
@@ -140,7 +140,7 @@
     },
     {
       "name": "Charge Scheduling",
-      "group": "CodeChef - AUG21B",
+      "group": "CodeChef - August Challenge 2021 Division 2 (Unrated)",
       "url": "https://www.codechef.com/AUG21B/problems/CHARGE",
       "interactive": false,
       "memoryLimit": 256,
@@ -167,7 +167,7 @@
     },
     {
       "name": "Geometry 1",
-      "group": "CodeChef - AUG21B",
+      "group": "CodeChef - August Challenge 2021 Division 2 (Unrated)",
       "url": "https://www.codechef.com/AUG21B/problems/GEO1",
       "interactive": false,
       "memoryLimit": 256,
@@ -194,7 +194,7 @@
     },
     {
       "name": "Fat Hut",
-      "group": "CodeChef - AUG21B",
+      "group": "CodeChef - August Challenge 2021 Division 2 (Unrated)",
       "url": "https://www.codechef.com/AUG21B/problems/FATHUT",
       "interactive": false,
       "memoryLimit": 256,
@@ -225,7 +225,7 @@
     },
     {
       "name": "Chef and Digits of Large Numbers",
-      "group": "CodeChef - AUG21B",
+      "group": "CodeChef - August Challenge 2021 Division 2 (Unrated)",
       "url": "https://www.codechef.com/AUG21B/problems/CDIGLNUM",
       "interactive": false,
       "memoryLimit": 256,
@@ -252,7 +252,7 @@
     },
     {
       "name": "Alternating LG Queries",
-      "group": "CodeChef - AUG21B",
+      "group": "CodeChef - August Challenge 2021 Division 2 (Unrated)",
       "url": "https://www.codechef.com/AUG21B/problems/ALTLG",
       "interactive": false,
       "memoryLimit": 256,

--- a/tests/data/codechef/problem/new-copy-button.json
+++ b/tests/data/codechef/problem/new-copy-button.json
@@ -4,7 +4,7 @@
   "before": "beforeCodeChefNew",
   "result": {
     "name": "Bus full of passengers",
-    "group": "CodeChef - START9",
+    "group": "CodeChef - Starters 9 (Rated for Div 3)",
     "url": "https://www.codechef.com/problems/BUS",
     "interactive": false,
     "memoryLimit": 256,

--- a/tests/data/codechef/problem/new-input-output-after-example-header.json
+++ b/tests/data/codechef/problem/new-input-output-after-example-header.json
@@ -4,7 +4,7 @@
   "before": "beforeCodeChefNew",
   "result": {
     "name": "Lapindromes",
-    "group": "CodeChef - JUNE13",
+    "group": "CodeChef - June Challenge 2013",
     "url": "https://www.codechef.com/problems/LAPIN",
     "interactive": false,
     "memoryLimit": 256,

--- a/tests/data/codechef/problem/new-input-output-as-normal-text.json
+++ b/tests/data/codechef/problem/new-input-output-as-normal-text.json
@@ -4,7 +4,7 @@
   "before": "beforeCodeChefNew",
   "result": {
     "name": "Fit Squares in Triangle",
-    "group": "CodeChef - COOK55",
+    "group": "CodeChef - February Cook-Off 2015",
     "url": "https://www.codechef.com/problems/TRISQ",
     "interactive": false,
     "memoryLimit": 256,

--- a/tests/data/codechef/problem/new-input-output-in-different-pre.json
+++ b/tests/data/codechef/problem/new-input-output-in-different-pre.json
@@ -4,7 +4,7 @@
   "before": "beforeCodeChefNew",
   "result": {
     "name": "Minimum Deletions",
-    "group": "CodeChef - MAY18B",
+    "group": "CodeChef - May Challenge 2018 Division 2",
     "url": "https://www.codechef.com/MAY18B/problems/RD19",
     "interactive": false,
     "memoryLimit": 256,

--- a/tests/data/codechef/problem/new-input-output-in-same-pre.json
+++ b/tests/data/codechef/problem/new-input-output-in-same-pre.json
@@ -4,7 +4,7 @@
   "before": "beforeCodeChefNew",
   "result": {
     "name": "Magic Elements",
-    "group": "CodeChef - LTIME58A",
+    "group": "CodeChef - March Lunchtime 2018 Division 1 (Unrated)",
     "url": "https://www.codechef.com/LTIME58A/problems/ZOZ",
     "interactive": false,
     "memoryLimit": 256,

--- a/tests/data/codechef/problem/new-tests-as-normal-text.json
+++ b/tests/data/codechef/problem/new-tests-as-normal-text.json
@@ -4,7 +4,7 @@
   "before": "beforeCodeChefNew",
   "result": {
     "name": "Total Graphs (keteki)",
-    "group": "CodeChef - KQ102018",
+    "group": "CodeChef - Keteki Quick Match 10",
     "url": "https://www.codechef.com/KQ102018/problems/QM10B",
     "interactive": false,
     "memoryLimit": 256,


### PR DESCRIPTION
## Summary
- The CodeChef parsers currently set the task group to the raw contest code (e.g. `START240A`, `LTIME58A`). The contest page itself shows the human-readable name (`Starters 240`, `March Lunchtime 2018 Division 1 (Unrated)`, etc.), and the same string is available from `/api/contests/<code>` as the `name` field.
- The problem parser now resolves whichever contest code it finds (from the in-page contest link, the URL path segment, or `intended_contest_code` for practice problems) to the API name. Any API error falls back to the original code, so behavior on outages is unchanged.
- The contest parser fetches the name once in `getTasksToParse` and threads it through to `parseTask`, so a contest with N problems still only makes one extra API call total.
- Updated the affected `new-*` problem fixtures and both contest fixtures to expect the resolved names.

## Test plan
- [x] `pnpm lint:eslint`
- [x] `pnpm lint:tsc`
- [x] `pnpm lint:prettier`
- [ ] `pnpm test -t codechef` — the `beforeCodeChefNew` selector (`#problem-statement > p`) currently times out for new-* fixtures on master too, so I couldn't verify the end-to-end run; the resolved names in the fixtures were checked manually against the live API.