### PR TITLE
Parse time and memory limits on Universal Cup problem pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## Unreleased
+- Parse the time and memory limits shown on Universal Cup problem pages instead of leaving them at the defaults
+
 ## [2.65.0](https://github.com/jmerle/competitive-companion/releases/tag/2.65.0) (2026-06-29)
 - Add support for Wincent DragonByte (thanks [@EgorKulikov](https://github.com/EgorKulikov))
 - Fix the Luogu problem parser reading the lower bound of a per-testdata time-limit range (e.g. "500ms ~ 3.00s" was treated as 500s instead of 3s) and set the contest name as the group when parsing contest-scoped problem URLs (thanks [@EgorKulikov](https://github.com/EgorKulikov))

--- a/src/parsers/problem/UniversalCupProblemParser.ts
+++ b/src/parsers/problem/UniversalCupProblemParser.ts
@@ -16,6 +16,21 @@ export class UniversalCupProblemParser extends Parser {
     task.setName(elem.querySelector('h1.text-center').textContent.replace(/\s+/g, ' ').trim());
     task.setCategory(elem.querySelector('h1.text-left').textContent.replace(/\s+/g, ' ').trim());
 
+    for (const badge of elem.querySelectorAll('span.badge')) {
+      const text = badge.textContent.replace(/\s+/g, ' ').trim();
+      const timeMatch = text.match(/^Time Limit:\s*([0-9.]+)\s*(ms|s)\b/i);
+      if (timeMatch !== null) {
+        const value = parseFloat(timeMatch[1]);
+        task.setTimeLimit(Math.round(timeMatch[2].toLowerCase() === 'ms' ? value : value * 1000));
+        continue;
+      }
+      const memoryMatch = text.match(/^Memory Limit:\s*([0-9.]+)\s*(MB|GB)\b/i);
+      if (memoryMatch !== null) {
+        const value = parseFloat(memoryMatch[1]);
+        task.setMemoryLimit(Math.round(memoryMatch[2].toUpperCase() === 'GB' ? value * 1024 : value));
+      }
+    }
+
     const attachmentsUrlElem = elem.querySelector<HTMLLinkElement>('a.nav-link[href^="/download"]');
     if (attachmentsUrlElem === null) {
       return task.build();


### PR DESCRIPTION
## Summary
- The Universal Cup problem parser doesn't read the time or memory limit from the page, so every task ends up with the `TaskBuilder` defaults (1 s, 256 MB). For e.g. https://contest.ucup.ac/contest/3749/problem/18120 the real limits are 5 s and 1024 MB.
- The values live in `span.badge` elements at the top of the problem page (`Time Limit: 5.0 s`, `Memory Limit: 1024 MB`). Walk those badges, parse with a regex, and call `setTimeLimit` / `setMemoryLimit`. Handles `s`/`ms` for time and `MB`/`GB` for memory.

## Test plan
- [x] `pnpm lint:eslint`
- [x] `pnpm lint:tsc`
- [x] `pnpm lint:prettier`
- [x] Verified manually against https://contest.ucup.ac/contest/3749/problem/18120 — parser now returns `timeLimit: 5000`, `memoryLimit: 1024`.