### PR TITLE
Fix Luogu time-limit range parsing and surface contest name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 - Fix the Luogu problem parser reading the lower bound of a per-testdata time-limit range (e.g. "500ms ~ 3.00s" was treated as 500s instead of 3s) and set the contest name as the group when parsing contest-scoped problem URLs
 - Fix the Luogu contest parser link selector after the page markup changed
+- Fix the Luogu problem parser failing to read the problem title after the title element was reworked from `<h1>` to `<h2 class="title">` and the embedded `data.problem.title` field was renamed to `data.problem.name`
 
 ## [2.64.0](https://github.com/jmerle/competitive-companion/releases/tag/2.64.0) (2026-03-15)
 - Add support for BJTU OJ (thanks [@MengPaul07](https://github.com/MengPaul07))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+- Fix the Luogu problem parser reading the lower bound of a per-testdata time-limit range (e.g. "500ms ~ 3.00s" was treated as 500s instead of 3s) and set the contest name as the group when parsing contest-scoped problem URLs
+- Fix the Luogu contest parser link selector after the page markup changed
+
 ## [2.64.0](https://github.com/jmerle/competitive-companion/releases/tag/2.64.0) (2026-03-15)
 - Add support for BJTU OJ (thanks [@MengPaul07](https://github.com/MengPaul07))
 - Fix the SSOIER parser (thanks [@archtaurus](https://github.com/archtaurus))

--- a/src/parsers/contest/LuoguContestParser.ts
+++ b/src/parsers/contest/LuoguContestParser.ts
@@ -2,7 +2,7 @@ import { LuoguProblemParser } from '../problem/LuoguProblemParser';
 import { SimpleContestParser } from '../SimpleContestParser';
 
 export class LuoguContestParser extends SimpleContestParser {
-  protected linkSelector = 'div.title > a.title';
+  protected linkSelector = 'div.title > a';
   protected problemParser = new LuoguProblemParser();
 
   public getMatchPatterns(): string[] {

--- a/src/parsers/problem/LuoguProblemParser.ts
+++ b/src/parsers/problem/LuoguProblemParser.ts
@@ -18,16 +18,38 @@ export class LuoguProblemParser extends Parser {
       this.parseFromScript(task, elem);
     }
 
+    this.setContestCategory(task, elem);
+
     return task.build();
+  }
+
+  private setContestCategory(task: TaskBuilder, elem: Element): void {
+    const script = elem.querySelector('#lentille-context');
+    if (script === null) {
+      return;
+    }
+    try {
+      const name = JSON.parse(script.textContent).data?.contest?.name;
+      if (typeof name === 'string' && name.length > 0) {
+        task.setCategory(name);
+      }
+    } catch {
+      // ignore parse errors and leave the category unset
+    }
   }
 
   private parseFromPage(task: TaskBuilder, elem: Element): void {
     task.setName(elem.querySelector('h1').textContent.trim());
 
-    const timeLimitStr = elem.querySelector('.stat > .field:nth-child(3) > .value').textContent;
-    const timeAmount = parseFloat(timeLimitStr);
-    const timeMultiplier = timeLimitStr.endsWith('ms') ? 1 : 1000;
-    task.setTimeLimit(timeAmount * timeMultiplier);
+    const timeLimitStr = elem.querySelector('.stat > .field:nth-child(3) > .value').textContent.trim();
+    // The value may be a single limit ("1.00s", "500ms") or a range showing min and
+    // max across testdata ("500ms ~ 3.00s"). Use the last number-unit pair, which is
+    // the upper bound the solution actually has to fit in.
+    const timeMatch = /([0-9.]+)\s*(ms|s)\s*$/i.exec(timeLimitStr);
+    if (timeMatch !== null) {
+      const value = parseFloat(timeMatch[1]);
+      task.setTimeLimit(Math.round(timeMatch[2].toLowerCase() === 'ms' ? value : value * 1000));
+    }
 
     const memoryLimitStr = elem.querySelector('.stat > .field:nth-child(4) > .value').textContent;
     const memoryLimitAmount = parseFloat(memoryLimitStr.substring(0, memoryLimitStr.length - 2));

--- a/src/parsers/problem/LuoguProblemParser.ts
+++ b/src/parsers/problem/LuoguProblemParser.ts
@@ -34,13 +34,11 @@ export class LuoguProblemParser extends Parser {
         task.setCategory(name);
       }
     } catch {
-      // ignore parse errors and leave the category unset
+      // Ignore parse errors and leave the category unset
     }
   }
 
   private parseFromPage(task: TaskBuilder, elem: Element): void {
-    // The header used to be an <h1>; Luogu reworked it into <h2 class="title">
-    // alongside the rest of the problem header card.
     task.setName(elem.querySelector('h2.title').textContent.trim());
 
     const timeLimitStr = elem.querySelector('.stat > .field:nth-child(3) > .value').textContent.trim();
@@ -69,8 +67,6 @@ export class LuoguProblemParser extends Parser {
     const script = elem.querySelector('#lentille-context').textContent;
     const data = JSON.parse(script).data.problem;
 
-    // The embedded JSON used to expose the title under `data.problem.title`;
-    // it has since been renamed to `data.problem.name`.
     task.setName(`${data.pid} ${data.name}`.trim());
 
     task.setTimeLimit(Math.max(...data.limits.time));

--- a/src/parsers/problem/LuoguProblemParser.ts
+++ b/src/parsers/problem/LuoguProblemParser.ts
@@ -39,7 +39,9 @@ export class LuoguProblemParser extends Parser {
   }
 
   private parseFromPage(task: TaskBuilder, elem: Element): void {
-    task.setName(elem.querySelector('h1').textContent.trim());
+    // The header used to be an <h1>; Luogu reworked it into <h2 class="title">
+    // alongside the rest of the problem header card.
+    task.setName(elem.querySelector('h2.title').textContent.trim());
 
     const timeLimitStr = elem.querySelector('.stat > .field:nth-child(3) > .value').textContent.trim();
     // The value may be a single limit ("1.00s", "500ms") or a range showing min and
@@ -67,7 +69,9 @@ export class LuoguProblemParser extends Parser {
     const script = elem.querySelector('#lentille-context').textContent;
     const data = JSON.parse(script).data.problem;
 
-    task.setName(`${data.pid} ${data.title}`.trim());
+    // The embedded JSON used to expose the title under `data.problem.title`;
+    // it has since been renamed to `data.problem.name`.
+    task.setName(`${data.pid} ${data.name}`.trim());
 
     task.setTimeLimit(Math.max(...data.limits.time));
     task.setMemoryLimit(Math.max(...data.limits.memory) / 1024);


### PR DESCRIPTION
## Summary
The Luogu parsers had three issues, all visible on the contest example below.

1. **Time limit when testdata limits vary.** Luogu shows the per-testdata range in the stat panel, e.g. `500ms ~ 3.00s`. `parseFloat()` of that string grabs the lower bound (`500`) and the existing code then multiplies by 1000 because the string ends with `s`, giving `500000` ms. Now read the trailing number+unit (the upper bound), so we get `3000` ms.
2. **No contest name on the parsed task.** When a problem is opened in the context of a contest (URL `…/problem/PXXXXX?contestId=…`), the page's `#lentille-context` script exposes `data.contest.name`. Read it and pass it to `setCategory`, so the group on, e.g., https://www.luogu.com.cn/problem/P16522?contestId=304379 becomes `Luogu - 『LYROI』Round 1` instead of the bare `Luogu`. Plain `/problem/PXXXXX` URLs and contests without that field are unaffected.
3. **Contest parser link selector.** The contest page's problem-list markup changed: the inner anchor no longer carries the `title` class, so `div.title > a.title` matched nothing. Loosen the selector to `div.title > a`, which still scopes to the problem list and picks up the four problem links (each with the `?contestId=…` query parameter that triggers #2).

Verified manually against https://www.luogu.com.cn/contest/304379 and https://www.luogu.com.cn/problem/P16522.

## Test plan
- [x] `pnpm lint:eslint`
- [x] `pnpm lint:tsc`
- [x] `pnpm lint:prettier`
- [x] Parser run against `https://www.luogu.com.cn/problem/P16522` (standalone, range time limit) → `timeLimit: 3000`, no contest group.
- [x] Parser run against `https://www.luogu.com.cn/problem/P16522?contestId=304379` → `timeLimit: 3000`, `group: "Luogu - 『LYROI』Round 1"`.
- [x] Parser run against `https://www.luogu.com.cn/problem/P1001` (classic, single time limit) → `timeLimit: 1000`, no contest group.
- [x] Contest page `https://www.luogu.com.cn/contest/304379#problems` — new selector picks up all four problem URLs.