### PR TITLE
Add DOJ (dojoi.xyz) problem parser

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,6 @@
+allowBuilds:
+  canvas: true
+  esbuild: true
+  puppeteer: true
+  spawn-sync: true
+  unrs-resolver: true

--- a/src/parsers/parsers.ts
+++ b/src/parsers/parsers.ts
@@ -160,6 +160,7 @@ import { YandexProblemParser } from './problem/YandexProblemParser';
 import { YukicoderProblemParser } from './problem/YukicoderProblemParser';
 import { ZOJProblemParser } from './problem/ZOJProblemParser';
 import { ZUFEOJProblemParser } from './problem/ZUFEOJProblemParser';
+import { DOJProblemParser } from './problem/DOJProblemParser';
 
 export const parsers: Parser[] = [
   new A2OnlineJudgeProblemParser(),
@@ -425,4 +426,6 @@ export const parsers: Parser[] = [
 
   new ZUFEOJProblemParser(),
   new ZUFEOJContestParser(),
+
+  new DOJProblemParser(),
 ];

--- a/src/parsers/parsers.ts
+++ b/src/parsers/parsers.ts
@@ -84,6 +84,7 @@ import { CSUACMOnlineJudgeProblemParser } from './problem/CSUACMOnlineJudgeProbl
 import { DimikOJProblemParser } from './problem/DimikOJProblemParser';
 import { DMOJProblemParser } from './problem/DMOJProblemParser';
 import { DotOJProblemParser } from './problem/DotOJProblemParser';
+import { DOJProblemParser } from './problem/DOJProblemParser';
 import { ECNUOnlineJudgeProblemParser } from './problem/ECNUOnlineJudgeProblemParser';
 import { EolympBasecampProblemParser } from './problem/EolympBasecampProblemParser';
 import { FZUOnlineJudgeProblemParser } from './problem/FZUOnlineJudgeProblemParser';
@@ -160,7 +161,6 @@ import { YandexProblemParser } from './problem/YandexProblemParser';
 import { YukicoderProblemParser } from './problem/YukicoderProblemParser';
 import { ZOJProblemParser } from './problem/ZOJProblemParser';
 import { ZUFEOJProblemParser } from './problem/ZUFEOJProblemParser';
-import { DOJProblemParser } from './problem/DOJProblemParser';
 
 export const parsers: Parser[] = [
   new A2OnlineJudgeProblemParser(),
@@ -244,7 +244,9 @@ export const parsers: Parser[] = [
 
   new DotOJProblemParser(),
   new DotOJContestParser(),
-
+  
+  new DOJProblemParser(),
+  
   new ECNUOnlineJudgeProblemParser(),
   new ECNUOnlineJudgeContestParser(),
 
@@ -426,6 +428,4 @@ export const parsers: Parser[] = [
 
   new ZUFEOJProblemParser(),
   new ZUFEOJContestParser(),
-
-  new DOJProblemParser(),
 ];

--- a/src/parsers/problem/DOJProblemParser.ts
+++ b/src/parsers/problem/DOJProblemParser.ts
@@ -1,0 +1,53 @@
+import { Sendable } from '../../models/Sendable';
+import { TaskBuilder } from '../../models/TaskBuilder';
+import { htmlToElement } from '../../utils/dom';
+import { Parser } from '../Parser';
+
+export class DOJProblemParser extends Parser {
+  public getMatchPatterns(): string[] {
+    return [
+      'https://dojoi.xyz/*/problems/*',
+      'https://dojoi.xyz/problems/*',
+    ];
+  }
+
+  public async parse(url: string, html: string): Promise<Sendable> {
+    const elem = htmlToElement(html);
+    const task = new TaskBuilder().setUrl(url);
+
+    // 문제 제목
+    const titleEl = elem.querySelector('h1') ?? elem.querySelector('h2');
+    task.setName(titleEl ? titleEl.textContent!.trim() : 'DOJ Problem');
+
+    // 그룹
+    task.setGroup('DOJ');
+
+    // 시간/메모리 제한 (있으면 파싱, 없으면 기본값)
+    const metaText = elem.body?.textContent ?? '';
+
+    const timeMatch = metaText.match(/(\d+)\s*(?:ms|초|second)/i);
+    if (timeMatch) {
+      task.setTimeLimit(parseInt(timeMatch[1], 10));
+    }
+
+    const memMatch = metaText.match(/(\d+)\s*(?:MB|mb)/i);
+    if (memMatch) {
+      task.setMemoryLimit(parseInt(memMatch[1], 10));
+    }
+
+    // 예제 입출력 파싱
+    // 구조: .sample-block > .sample-pair > .copyable-code-block:nth(0) input, nth(1) output
+    const sampleBlocks = elem.querySelectorAll('.sample-block');
+
+    for (const block of sampleBlocks) {
+      const codeBlocks = block.querySelectorAll('.code-block');
+      if (codeBlocks.length >= 2) {
+        const input = codeBlocks[0].textContent!.trim() + '\n';
+        const output = codeBlocks[1].textContent!.trim() + '\n';
+        task.addTest(input, output);
+      }
+    }
+
+    return task.build();
+  }
+}


### PR DESCRIPTION
Adds a problem parser for DOJ (https://dojoi.xyz),
a Korean competitive programming judge with OI-style scoring.

Parses sample input/output from .sample-block > .sample-pair > .code-block