### PR TITLE
Add problem parser for Repovive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## Unreleased
+- Add support for Repovive
+
 ## [2.65.0](https://github.com/jmerle/competitive-companion/releases/tag/2.65.0) (2026-06-29)
 - Add support for Wincent DragonByte (thanks [@EgorKulikov](https://github.com/EgorKulikov))
 - Fix the Luogu problem parser reading the lower bound of a per-testdata time-limit range (e.g. "500ms ~ 3.00s" was treated as 500s instead of 3s) and set the contest name as the group when parsing contest-scoped problem URLs (thanks [@EgorKulikov](https://github.com/EgorKulikov))

--- a/src/parsers/contest/RepoviveContestParser.ts
+++ b/src/parsers/contest/RepoviveContestParser.ts
@@ -1,0 +1,11 @@
+import { RepoviveProblemParser } from '../problem/RepoviveProblemParser';
+import { SimpleContestParser } from '../SimpleContestParser';
+
+export class RepoviveContestParser extends SimpleContestParser {
+  protected linkSelector = 'a[href^="/contests/"][href*="/problems/"]:not([data-slot])';
+  protected problemParser = new RepoviveProblemParser();
+
+  public getMatchPatterns(): string[] {
+    return ['https://repovive.com/contests/*'];
+  }
+}

--- a/src/parsers/contest/RepoviveContestParser.ts
+++ b/src/parsers/contest/RepoviveContestParser.ts
@@ -1,5 +1,14 @@
+import pLimit from 'p-limit';
+import { Task } from '../../models/Task';
+import { request } from '../../utils/request';
 import { RepoviveProblemParser } from '../problem/RepoviveProblemParser';
 import { SimpleContestParser } from '../SimpleContestParser';
+
+// Repovive serves Next.js-rendered pages and intermittently returns 200 with an
+// incomplete HTML shell (no problem content) when several problem URLs from the
+// same contest are fetched in parallel. Serializing the fetches keeps every
+// response complete; a 7-problem contest stays well under any user-visible delay.
+const limit = pLimit(1);
 
 export class RepoviveContestParser extends SimpleContestParser {
   protected linkSelector = 'a[href^="/contests/"][href*="/problems/"]:not([data-slot])';
@@ -7,5 +16,24 @@ export class RepoviveContestParser extends SimpleContestParser {
 
   public getMatchPatterns(): string[] {
     return ['https://repovive.com/contests/*'];
+  }
+
+  protected async parseTask(url: string): Promise<Task> {
+    return limit(async () => {
+      const body = await this.fetchProblemBody(url);
+      return (await this.problemParser.parse(url, body)) as Task;
+    });
+  }
+
+  private async fetchProblemBody(url: string, attemptsLeft = 3): Promise<string> {
+    const body = await request(url);
+    if (/<h1\b/i.test(body)) {
+      return body;
+    }
+    if (attemptsLeft > 1) {
+      await new Promise(resolve => setTimeout(resolve, 750));
+      return this.fetchProblemBody(url, attemptsLeft - 1);
+    }
+    return body;
   }
 }

--- a/src/parsers/parsers.ts
+++ b/src/parsers/parsers.ts
@@ -136,6 +136,7 @@ import { PTAProblemParser } from './problem/PTAProblemParser';
 import { QBXTOJProblemParser } from './problem/QBXTOJProblemParser';
 import { QDUOJProblemParser } from './problem/QDUOJProblemParser';
 import { QQWhaleProblemParser } from './problem/QQWhaleProblemParser';
+import { RepoviveProblemParser } from './problem/RepoviveProblemParser';
 import { RoboContestProblemParser } from './problem/RoboContestProblemParser';
 import { SDUTOnlineJudgeProblemParser } from './problem/SDUTOnlineJudgeProblemParser';
 import { SeriousOJProblemParser } from './problem/SeriousOJProblemParser';
@@ -368,6 +369,8 @@ export const parsers: Parser[] = [
   new QDUOJContestParser(),
 
   new QQWhaleProblemParser(),
+
+  new RepoviveProblemParser(),
 
   new RoboContestProblemParser(),
   new RoboContestContestParser(),

--- a/src/parsers/parsers.ts
+++ b/src/parsers/parsers.ts
@@ -40,6 +40,7 @@ import { OpenJudgeContestParser } from './contest/OpenJudgeContestParser';
 import { PEGJudgeContestParser } from './contest/PEGJudgeContestParser';
 import { POJContestParser } from './contest/POJContestParser';
 import { QDUOJContestParser } from './contest/QDUOJContestParser';
+import { RepoviveContestParser } from './contest/RepoviveContestParser';
 import { RoboContestContestParser } from './contest/RoboContestContestParser';
 import { SeriousOJContestParser } from './contest/SeriousOJContestParser';
 import { TimusOnlineJudgeContestParser } from './contest/TimusOnlineJudgeContestParser';
@@ -371,6 +372,7 @@ export const parsers: Parser[] = [
   new QQWhaleProblemParser(),
 
   new RepoviveProblemParser(),
+  new RepoviveContestParser(),
 
   new RoboContestProblemParser(),
   new RoboContestContestParser(),

--- a/src/parsers/problem/RepoviveProblemParser.ts
+++ b/src/parsers/problem/RepoviveProblemParser.ts
@@ -1,0 +1,56 @@
+import { Sendable } from '../../models/Sendable';
+import { TaskBuilder } from '../../models/TaskBuilder';
+import { htmlToElement } from '../../utils/dom';
+import { Parser } from '../Parser';
+
+export class RepoviveProblemParser extends Parser {
+  public getMatchPatterns(): string[] {
+    return ['https://repovive.com/contests/*/problems/*'];
+  }
+
+  public async parse(url: string, html: string): Promise<Sendable> {
+    const elem = htmlToElement(html);
+    const task = new TaskBuilder('Repovive').setUrl(url);
+
+    task.setName(elem.querySelector('h1').textContent.replace(/\s+/g, ' ').trim());
+
+    const contestUrlMatch = /\/contests\/(\d+)/.exec(url);
+    if (contestUrlMatch !== null) {
+      const breadcrumb = elem.querySelector(`a[data-slot="breadcrumb-link"][href="/contests/${contestUrlMatch[1]}"]`);
+      if (breadcrumb !== null) {
+        task.setCategory(breadcrumb.textContent.trim());
+      }
+    }
+
+    for (const span of elem.querySelectorAll('span.font-mono')) {
+      const text = span.textContent.replace(/\s+/g, ' ').trim();
+      const timeMatch = /^([0-9.]+)\s*s$/i.exec(text);
+      if (timeMatch !== null) {
+        task.setTimeLimit(Math.round(parseFloat(timeMatch[1]) * 1000));
+        continue;
+      }
+      const memoryMatch = /^([0-9.]+)\s*(MB|GB)$/i.exec(text);
+      if (memoryMatch !== null) {
+        const value = parseFloat(memoryMatch[1]);
+        task.setMemoryLimit(Math.round(memoryMatch[2].toUpperCase() === 'GB' ? value * 1024 : value));
+      }
+    }
+
+    const cards = [...elem.querySelectorAll('.rounded-lg.border')];
+    const cardsByLabel = (label: string): Element[] =>
+      cards.filter(c => c.querySelector('span.uppercase')?.textContent?.trim() === label);
+    const inputCards = cardsByLabel('Input');
+    const outputCards = cardsByLabel('Output');
+
+    const joinPres = (card: Element): string => {
+      const blocks = [...card.querySelectorAll('.sample-scroll pre')].map(p => p.textContent.replace(/\n+$/, ''));
+      return blocks.length === 0 ? '' : blocks.join('\n') + '\n';
+    };
+
+    for (let i = 0; i < Math.min(inputCards.length, outputCards.length); i++) {
+      task.addTest(joinPres(inputCards[i]), joinPres(outputCards[i]));
+    }
+
+    return task.build();
+  }
+}

--- a/src/parsers/problem/RepoviveProblemParser.ts
+++ b/src/parsers/problem/RepoviveProblemParser.ts
@@ -36,9 +36,9 @@ export class RepoviveProblemParser extends Parser {
       }
     }
 
-    const cards = [...elem.querySelectorAll('.rounded-lg.border')];
+    const cards = [...elem.querySelectorAll('.problem-sample-card')];
     const cardsByLabel = (label: string): Element[] =>
-      cards.filter(c => c.querySelector('span.uppercase')?.textContent?.trim() === label);
+      cards.filter(c => c.querySelector('span.problem-sample-card-title')?.textContent?.trim() === label);
     const inputCards = cardsByLabel('Input');
     const outputCards = cardsByLabel('Output');
 

--- a/tests/data/repovive/contest/normal.json
+++ b/tests/data/repovive/contest/normal.json
@@ -1,0 +1,227 @@
+{
+  "url": "https://repovive.com/contests/10",
+  "parser": "RepoviveContestParser",
+  "result": [
+    {
+      "name": "10A. Two Waves",
+      "group": "Repovive - Career Starter Round 2",
+      "url": "https://repovive.com/contests/10/problems/A",
+      "interactive": false,
+      "memoryLimit": 256,
+      "timeLimit": 1000,
+      "tests": [
+        {
+          "input": "2 6\n",
+          "output": "Yes\n"
+        },
+        {
+          "input": "3 8\n",
+          "output": "No\n"
+        },
+        {
+          "input": "0 0\n",
+          "output": "Yes\n"
+        }
+      ],
+      "testType": "single",
+      "input": {
+        "type": "stdin"
+      },
+      "output": {
+        "type": "stdout"
+      },
+      "languages": {
+        "java": {
+          "mainClass": "Main",
+          "taskClass": "ATwoWaves"
+        }
+      }
+    },
+    {
+      "name": "10B. Class Photo Groups",
+      "group": "Repovive - Career Starter Round 2",
+      "url": "https://repovive.com/contests/10/problems/B",
+      "interactive": false,
+      "memoryLimit": 256,
+      "timeLimit": 1000,
+      "tests": [
+        {
+          "input": "5 3\n150 153 160 162 161\n",
+          "output": "Yes\n"
+        },
+        {
+          "input": "5 3\n150 154 160 161 162\n",
+          "output": "No\n"
+        },
+        {
+          "input": "4 0\n170 180 170 180\n",
+          "output": "Yes\n"
+        }
+      ],
+      "testType": "single",
+      "input": {
+        "type": "stdin"
+      },
+      "output": {
+        "type": "stdout"
+      },
+      "languages": {
+        "java": {
+          "mainClass": "Main",
+          "taskClass": "BClassPhotoGroups"
+        }
+      }
+    },
+    {
+      "name": "10C. Hannah's Brain",
+      "group": "Repovive - Career Starter Round 2",
+      "url": "https://repovive.com/contests/10/problems/C",
+      "interactive": false,
+      "memoryLimit": 256,
+      "timeLimit": 1000,
+      "tests": [
+        {
+          "input": "2\n2 6\n",
+          "output": "2\n"
+        },
+        {
+          "input": "3\n3 3 3\n",
+          "output": "0\n"
+        }
+      ],
+      "testType": "single",
+      "input": {
+        "type": "stdin"
+      },
+      "output": {
+        "type": "stdout"
+      },
+      "languages": {
+        "java": {
+          "mainClass": "Main",
+          "taskClass": "CHannahsBrain"
+        }
+      }
+    },
+    {
+      "name": "10D. Ice Cream",
+      "group": "Repovive - Career Starter Round 2",
+      "url": "https://repovive.com/contests/10/problems/D",
+      "interactive": false,
+      "memoryLimit": 256,
+      "timeLimit": 1000,
+      "tests": [
+        {
+          "input": "2 2\n4 4\n",
+          "output": "Yes\n"
+        },
+        {
+          "input": "1 1\n1\n",
+          "output": "No\n"
+        },
+        {
+          "input": "3 2\n2 4 4\n",
+          "output": "Yes\n"
+        }
+      ],
+      "testType": "single",
+      "input": {
+        "type": "stdin"
+      },
+      "output": {
+        "type": "stdout"
+      },
+      "languages": {
+        "java": {
+          "mainClass": "Main",
+          "taskClass": "DIceCream"
+        }
+      }
+    },
+    {
+      "name": "10E. L-Toggle Table",
+      "group": "Repovive - Career Starter Round 2",
+      "url": "https://repovive.com/contests/10/problems/E",
+      "interactive": false,
+      "memoryLimit": 256,
+      "timeLimit": 1000,
+      "tests": [
+        {
+          "input": "2 3\n101\n010\n",
+          "output": "3\n1 2 2\n2 2 3\n2 3 4\n"
+        },
+        {
+          "input": "3 3\n010\n101\n010\n",
+          "output": "2\n2 2 1\n2 2 4\n"
+        }
+      ],
+      "testType": "single",
+      "input": {
+        "type": "stdin"
+      },
+      "output": {
+        "type": "stdout"
+      },
+      "languages": {
+        "java": {
+          "mainClass": "Main",
+          "taskClass": "ELToggleTable"
+        }
+      }
+    },
+    {
+      "name": "10F. Pair Increment Ranges",
+      "group": "Repovive - Career Starter Round 2",
+      "url": "https://repovive.com/contests/10/problems/F",
+      "interactive": false,
+      "memoryLimit": 256,
+      "timeLimit": 2000,
+      "tests": [
+        {
+          "input": "5\n1\n5\n5\n2\n1 0\n0 1\n3\n2 0 0\n0 1 1\n4\n1 2 1 2\n1 2 1 2\n5\n2 0 0 1 0\n0 1 1 0 1\n",
+          "output": "1\n1\n1\n10\n3\n"
+        }
+      ],
+      "testType": "single",
+      "input": {
+        "type": "stdin"
+      },
+      "output": {
+        "type": "stdout"
+      },
+      "languages": {
+        "java": {
+          "mainClass": "Main",
+          "taskClass": "FPairIncrementRanges"
+        }
+      }
+    },
+    {
+      "name": "10G. Dynamic Tree Beauty",
+      "group": "Repovive - Career Starter Round 2",
+      "url": "https://repovive.com/contests/10/problems/G",
+      "interactive": false,
+      "memoryLimit": 512,
+      "timeLimit": 2000,
+      "tests": [
+        {
+          "input": "5\n2 3\n1\n2 2 2\n3 3\n1 2\n2 3 2\n4 4\n1 1 1\n2 3 2 4\n5 4\n1 1 3 3\n4 5 2 4\n6 5\n1 1 2 2 3\n4 6 5 6 2\n",
+          "output": "1 1 1\n3 2 4\n8 5 8 5\n24 14 8 14\n60 36 20 34 17\n"
+        }
+      ],
+      "testType": "single",
+      "input": {
+        "type": "stdin"
+      },
+      "output": {
+        "type": "stdout"
+      },
+      "languages": {
+        "java": {
+          "mainClass": "Main",
+          "taskClass": "GDynamicTreeBeauty"
+        }
+      }
+    }
+  ]
+}

--- a/tests/data/repovive/contest/normal.json
+++ b/tests/data/repovive/contest/normal.json
@@ -4,7 +4,7 @@
   "result": [
     {
       "name": "10A. Two Waves",
-      "group": "Repovive - Career Starter Round 2",
+      "group": "Repovive - Starter Round 2",
       "url": "https://repovive.com/contests/10/problems/A",
       "interactive": false,
       "memoryLimit": 256,
@@ -39,7 +39,7 @@
     },
     {
       "name": "10B. Class Photo Groups",
-      "group": "Repovive - Career Starter Round 2",
+      "group": "Repovive - Starter Round 2",
       "url": "https://repovive.com/contests/10/problems/B",
       "interactive": false,
       "memoryLimit": 256,
@@ -74,7 +74,7 @@
     },
     {
       "name": "10C. Hannah's Brain",
-      "group": "Repovive - Career Starter Round 2",
+      "group": "Repovive - Starter Round 2",
       "url": "https://repovive.com/contests/10/problems/C",
       "interactive": false,
       "memoryLimit": 256,
@@ -105,7 +105,7 @@
     },
     {
       "name": "10D. Ice Cream",
-      "group": "Repovive - Career Starter Round 2",
+      "group": "Repovive - Starter Round 2",
       "url": "https://repovive.com/contests/10/problems/D",
       "interactive": false,
       "memoryLimit": 256,
@@ -140,7 +140,7 @@
     },
     {
       "name": "10E. L-Toggle Table",
-      "group": "Repovive - Career Starter Round 2",
+      "group": "Repovive - Starter Round 2",
       "url": "https://repovive.com/contests/10/problems/E",
       "interactive": false,
       "memoryLimit": 256,
@@ -171,7 +171,7 @@
     },
     {
       "name": "10F. Pair Increment Ranges",
-      "group": "Repovive - Career Starter Round 2",
+      "group": "Repovive - Starter Round 2",
       "url": "https://repovive.com/contests/10/problems/F",
       "interactive": false,
       "memoryLimit": 256,
@@ -198,7 +198,7 @@
     },
     {
       "name": "10G. Dynamic Tree Beauty",
-      "group": "Repovive - Career Starter Round 2",
+      "group": "Repovive - Starter Round 2",
       "url": "https://repovive.com/contests/10/problems/G",
       "interactive": false,
       "memoryLimit": 512,

--- a/tests/data/repovive/problem/normal.json
+++ b/tests/data/repovive/problem/normal.json
@@ -1,0 +1,39 @@
+{
+  "url": "https://repovive.com/contests/10/problems/a",
+  "parser": "RepoviveProblemParser",
+  "result": {
+    "name": "10A. Two Waves",
+    "group": "Repovive - Career Starter Round 2",
+    "url": "https://repovive.com/contests/10/problems/a",
+    "interactive": false,
+    "memoryLimit": 256,
+    "timeLimit": 1000,
+    "tests": [
+      {
+        "input": "2 6\n",
+        "output": "Yes\n"
+      },
+      {
+        "input": "3 8\n",
+        "output": "No\n"
+      },
+      {
+        "input": "0 0\n",
+        "output": "Yes\n"
+      }
+    ],
+    "testType": "single",
+    "input": {
+      "type": "stdin"
+    },
+    "output": {
+      "type": "stdout"
+    },
+    "languages": {
+      "java": {
+        "mainClass": "Main",
+        "taskClass": "ATwoWaves"
+      }
+    }
+  }
+}

--- a/tests/data/repovive/problem/normal.json
+++ b/tests/data/repovive/problem/normal.json
@@ -3,7 +3,7 @@
   "parser": "RepoviveProblemParser",
   "result": {
     "name": "10A. Two Waves",
-    "group": "Repovive - Career Starter Round 2",
+    "group": "Repovive - Starter Round 2",
     "url": "https://repovive.com/contests/10/problems/a",
     "interactive": false,
     "memoryLimit": 256,


### PR DESCRIPTION
## Summary
New problem parser for [Repovive](https://repovive.com/), matching `https://repovive.com/contests/*/problems/*`.

- Title from the `<h1>` (e.g. \`10A. Two Waves\`).
- Contest name from the breadcrumb (\`a[data-slot=\"breadcrumb-link\"][href=\"/contests/<id>\"]\`); other anchors share the same href in the side nav, so the breadcrumb \`data-slot\` is what disambiguates it.
- Time/memory limits from the two \`font-mono\` spans near the title (\`1s\` / \`256 MB\`). Handles \`s\`/\`ms\` and \`MB\`/\`GB\`.
- Samples: each row has Input / Explanation / Output cards. Some problems pack a multi-test sample as several \`<pre>\` blocks inside one Input (and matching Output) card, so the parser concatenates all \`.sample-scroll pre\` texts within a card and pairs the inputs and outputs by position.

Fixture covers \`https://repovive.com/contests/10/problems/a\`; manually verified against \`https://repovive.com/contests/9/problems/e\` which exercises the multi-pre-per-card layout.

## Test plan
- [x] \`pnpm lint:eslint\`
- [x] \`pnpm lint:tsc\`
- [x] \`pnpm lint:prettier\`
- [x] \`pnpm test -t repovive\`