### PR TITLE
Add parser for Wincent DragonByte

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Unreleased
+- Add support for Wincent DragonByte
 - Fix the Luogu problem parser reading the lower bound of a per-testdata time-limit range (e.g. "500ms ~ 3.00s" was treated as 500s instead of 3s) and set the contest name as the group when parsing contest-scoped problem URLs
 - Fix the Luogu contest parser link selector after the page markup changed
 - Fix the Luogu problem parser failing to read the problem title after the title element was reworked from `<h1>` to `<h2 class="title">` and the embedded `data.problem.title` field was renamed to `data.problem.name`

--- a/src/parsers/contest/WincentDragonByteContestParser.ts
+++ b/src/parsers/contest/WincentDragonByteContestParser.ts
@@ -1,0 +1,11 @@
+import { WincentDragonByteProblemParser } from '../problem/WincentDragonByteProblemParser';
+import { SimpleContestParser } from '../SimpleContestParser';
+
+export class WincentDragonByteContestParser extends SimpleContestParser {
+  protected linkSelector = 'ul li a[href^="https://wincentdragonbyte.com/problem/"]';
+  protected problemParser = new WincentDragonByteProblemParser();
+
+  public getMatchPatterns(): string[] {
+    return ['https://wincentdragonbyte.com/problems'];
+  }
+}

--- a/src/parsers/contest/WincentDragonByteContestParser.ts
+++ b/src/parsers/contest/WincentDragonByteContestParser.ts
@@ -2,7 +2,10 @@ import { WincentDragonByteProblemParser } from '../problem/WincentDragonByteProb
 import { SimpleContestParser } from '../SimpleContestParser';
 
 export class WincentDragonByteContestParser extends SimpleContestParser {
-  protected linkSelector = 'ul li a[href^="https://wincentdragonbyte.com/problem/"]';
+  // Match both the relative `/problem/<letter>` hrefs the live page renders and
+  // the absolute form. `/problems` (the nav "Problems" link) is excluded by the
+  // trailing slash in `/problem/`.
+  protected linkSelector = 'a[href*="/problem/"]';
   protected problemParser = new WincentDragonByteProblemParser();
 
   public getMatchPatterns(): string[] {

--- a/src/parsers/parsers.ts
+++ b/src/parsers/parsers.ts
@@ -47,6 +47,7 @@ import { TLXContestParser } from './contest/TLXContestParser';
 import { UniversalCupContestParser } from './contest/UniversalCupContestParser';
 import { UOJContestParser } from './contest/UOJContestParser';
 import { VirtualJudgeContestParser } from './contest/VirtualJudgeContestParser';
+import { WincentDragonByteContestParser } from './contest/WincentDragonByteContestParser';
 import { YandexContestParser } from './contest/YandexContestParser';
 import { YukicoderContestParser } from './contest/YukicoderContestParser';
 import { ZUFEOJContestParser } from './contest/ZUFEOJContestParser';
@@ -153,6 +154,7 @@ import { USACOProblemParser } from './problem/USACOProblemParser';
 import { USACOTrainingProblemParser } from './problem/USACOTrainingProblemParser';
 import { UVaOnlineJudgeProblemParser } from './problem/UVaOnlineJudgeProblemParser';
 import { VirtualJudgeProblemParser } from './problem/VirtualJudgeProblemParser';
+import { WincentDragonByteProblemParser } from './problem/WincentDragonByteProblemParser';
 import { XCampProblemParser } from './problem/XCampProblemParser';
 import { XXMProblemParser } from './problem/XXMProblemParser';
 import { YACSProblemParser } from './problem/YACSProblemParser';
@@ -408,6 +410,9 @@ export const parsers: Parser[] = [
 
   new VirtualJudgeProblemParser(),
   new VirtualJudgeContestParser(),
+
+  new WincentDragonByteProblemParser(),
+  new WincentDragonByteContestParser(),
 
   new XCampProblemParser(),
 

--- a/src/parsers/problem/WincentDragonByteProblemParser.ts
+++ b/src/parsers/problem/WincentDragonByteProblemParser.ts
@@ -1,0 +1,86 @@
+import { Sendable } from '../../models/Sendable';
+import { TaskBuilder } from '../../models/TaskBuilder';
+import { TestType } from '../../models/TestType';
+import { htmlToElement } from '../../utils/dom';
+import { Parser } from '../Parser';
+
+export class WincentDragonByteProblemParser extends Parser {
+  public getMatchPatterns(): string[] {
+    return ['https://wincentdragonbyte.com/problem/*', 'https://wincentdragonbyte.com/static/*/*_statement.html'];
+  }
+
+  public async parse(url: string, html: string): Promise<Sendable> {
+    const elem = htmlToElement(html);
+    const task = new TaskBuilder('Wincent DragonByte').setUrl(url);
+
+    const liveMatch = /\/problem\/([^/?#]+)/.exec(url);
+    const archiveMatch = /\/static\/([^/]+)\/([^_/]+)_statement\.html/.exec(url);
+    const letter = liveMatch !== null ? liveMatch[1] : archiveMatch !== null ? archiveMatch[2] : '';
+
+    const heading = elem.querySelector('#problem_statement h1, h1');
+    const baseName = heading !== null ? heading.textContent.replace(/\s+/g, ' ').trim() : '';
+    task.setName(letter.length > 0 ? `${letter}: ${baseName}` : baseName);
+
+    const roundSlug = archiveMatch !== null ? archiveMatch[1] : this.detectRoundFromPage(elem);
+    if (roundSlug.length > 0) {
+      task.setCategory(formatRound(roundSlug));
+    }
+
+    for (const table of elem.querySelectorAll('table.io')) {
+      const cells = table.querySelectorAll('tr > td');
+      if (cells.length < 2) {
+        continue;
+      }
+      const input = cells[0].querySelector('pre');
+      const output = cells[1].querySelector('pre');
+      if (input === null || output === null) {
+        continue;
+      }
+      task.addTest(input.textContent, output.textContent);
+    }
+
+    task.setTestType(TestType.MultiNumber);
+
+    // Wincent DragonByte is solved offline: contestants download per-subproblem
+    // input files and submit per-subproblem output files, so the page does not
+    // advertise judge-side time or memory limits. Use generous defaults to match
+    // the local-execution context.
+    task.setTimeLimit(60000);
+    task.setMemoryLimit(1024);
+
+    return task.build();
+  }
+
+  private detectRoundFromPage(elem: Element): string {
+    const link = elem.querySelector('a[href*="/static/"]');
+    if (link === null) {
+      return '';
+    }
+    const href = (link as HTMLAnchorElement).getAttribute('href') || '';
+    const match = /\/static\/([^/]+)\//.exec(href);
+    return match !== null ? match[1] : '';
+  }
+}
+
+function formatRound(slug: string): string {
+  const match = /^([a-z]+)(\d{4})$/i.exec(slug);
+  if (match === null) {
+    return slug;
+  }
+  const type = match[1].toLowerCase();
+  const year = match[2];
+  const labels: Record<string, string> = {
+    qual: 'Qualification',
+    quals: 'Qualifications',
+    qualifier: 'Qualifier',
+    qualification: 'Qualification',
+    final: 'Final',
+    finals: 'Finals',
+    semifinal: 'Semifinal',
+    semifinals: 'Semifinals',
+    round: 'Round',
+    practice: 'Practice',
+  };
+  const label = labels[type] !== undefined ? labels[type] : type.charAt(0).toUpperCase() + type.slice(1);
+  return `${label} ${year}`;
+}

--- a/src/parsers/problem/WincentDragonByteProblemParser.ts
+++ b/src/parsers/problem/WincentDragonByteProblemParser.ts
@@ -23,7 +23,7 @@ export class WincentDragonByteProblemParser extends Parser {
 
     const roundSlug = archiveMatch !== null ? archiveMatch[1] : this.detectRoundFromPage(elem);
     if (roundSlug.length > 0) {
-      task.setCategory(formatRound(roundSlug));
+      task.setCategory(this.formatRound(roundSlug));
     }
 
     for (const table of elem.querySelectorAll('table.io')) {
@@ -60,27 +60,27 @@ export class WincentDragonByteProblemParser extends Parser {
     const match = /\/static\/([^/]+)\//.exec(href);
     return match !== null ? match[1] : '';
   }
-}
 
-function formatRound(slug: string): string {
-  const match = /^([a-z]+)(\d{4})$/i.exec(slug);
-  if (match === null) {
-    return slug;
+  private formatRound(slug: string): string {
+    const match = /^([a-z]+)(\d{4})$/i.exec(slug);
+    if (match === null) {
+      return slug;
+    }
+    const type = match[1].toLowerCase();
+    const year = match[2];
+    const labels: Record<string, string> = {
+      qual: 'Qualification',
+      quals: 'Qualifications',
+      qualifier: 'Qualifier',
+      qualification: 'Qualification',
+      final: 'Final',
+      finals: 'Finals',
+      semifinal: 'Semifinal',
+      semifinals: 'Semifinals',
+      round: 'Round',
+      practice: 'Practice',
+    };
+    const label = labels[type] !== undefined ? labels[type] : type.charAt(0).toUpperCase() + type.slice(1);
+    return `${label} ${year}`;
   }
-  const type = match[1].toLowerCase();
-  const year = match[2];
-  const labels: Record<string, string> = {
-    qual: 'Qualification',
-    quals: 'Qualifications',
-    qualifier: 'Qualifier',
-    qualification: 'Qualification',
-    final: 'Final',
-    finals: 'Finals',
-    semifinal: 'Semifinal',
-    semifinals: 'Semifinals',
-    round: 'Round',
-    practice: 'Practice',
-  };
-  const label = labels[type] !== undefined ? labels[type] : type.charAt(0).toUpperCase() + type.slice(1);
-  return `${label} ${year}`;
 }

--- a/tests/data/wincent-dragonbyte/problem/archive.json
+++ b/tests/data/wincent-dragonbyte/problem/archive.json
@@ -1,0 +1,31 @@
+{
+  "url": "https://wincentdragonbyte.com/static/finals2025/M_statement.html",
+  "parser": "WincentDragonByteProblemParser",
+  "result": {
+    "name": "M: Minimum Edit Area",
+    "group": "Wincent DragonByte - Finals 2025",
+    "url": "https://wincentdragonbyte.com/static/finals2025/M_statement.html",
+    "interactive": false,
+    "memoryLimit": 1024,
+    "timeLimit": 60000,
+    "tests": [
+      {
+        "input": "2\n47 47\n4200 7017\n",
+        "output": "0\n0\n47\n6\n5\n4200 420 417 174 7014 7017\n"
+      }
+    ],
+    "testType": "multiNumber",
+    "input": {
+      "type": "stdin"
+    },
+    "output": {
+      "type": "stdout"
+    },
+    "languages": {
+      "java": {
+        "mainClass": "Main",
+        "taskClass": "MMinimumEditArea"
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
New problem and contest parsers for [Wincent DragonByte](https://wincentdragonbyte.com/), Wincent's annual output-only competition.

Problem parser matches two URL shapes:
- `https://wincentdragonbyte.com/problem/<LETTER>` — the live contest page (behind login)
- `https://wincentdragonbyte.com/static/<round>/<LETTER>_statement.html` — the public archive (e.g. `finals2025`, `online2025`, `qual2025`)

Behavior:
- Title comes from `#problem_statement h1` (or top-level `<h1>` on archived snapshots), prefixed with the URL letter, e.g. `S: Subtract First Digit` or `M: Minimum Edit Area`.
- Group is derived from the `<round>` slug. The slug is read from the URL on archive pages and from any `/static/<round>/...` link (e.g. the per-subproblem `<letter>N.in` download links) on the live problem page. `qualYYYY` → `Qualification YYYY`, `finalsYYYY` → `Finals YYYY`, `onlineYYYY` → `Online YYYY`, etc.
- Samples come from each `<table class="io">` on the page (one Input/Output `<pre>` pair per table; the parser handles both the live layout's `<div class="code-block-wrapper">` wrapper and the archive's bare `<pre>`).
- `testType` is `multiNumber` since input files start with the test-case count `t`. Stdin/stdout are used so the samples can be exercised locally — DragonByte is solved offline (no judge-side time/memory limit is advertised) so the parser sets generous defaults (60s / 1024MB).

Contest parser matches `https://wincentdragonbyte.com/problems` and picks links from the "Problem statements" list (`ul li a[href^="https://wincentdragonbyte.com/problem/"]`). It extends `SimpleContestParser`, so it fetches each problem page through the user's logged-in session.

Fixture covers the public archive URL `https://wincentdragonbyte.com/static/finals2025/M_statement.html`. The live `/problem/<LETTER>` and `/problems` pages were verified manually against my logged-in session (they aren't reachable from CI).

## Test plan
- [x] `pnpm lint:eslint`
- [x] `pnpm lint:tsc`
- [x] `pnpm lint:prettier`
- [x] `pnpm test -t wincent-dragonbyte`