### PR TITLE
Fix Luogu parser

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -133,3 +133,4 @@ dist
 build-*/
 dist/
 firefox-tmp/
+pnpm-workspace.yaml

--- a/src/parsers/contest/LuoguContestParser.ts
+++ b/src/parsers/contest/LuoguContestParser.ts
@@ -2,7 +2,7 @@ import { LuoguProblemParser } from '../problem/LuoguProblemParser';
 import { SimpleContestParser } from '../SimpleContestParser';
 
 export class LuoguContestParser extends SimpleContestParser {
-  protected linkSelector = 'div.title > a.title';
+  protected linkSelector = 'div.title > a';
   protected problemParser = new LuoguProblemParser();
 
   public getMatchPatterns(): string[] {

--- a/src/parsers/problem/LuoguProblemParser.ts
+++ b/src/parsers/problem/LuoguProblemParser.ts
@@ -12,10 +12,10 @@ export class LuoguProblemParser extends Parser {
     const elem = htmlToElement(html);
     const task = new TaskBuilder('Luogu').setUrl(url);
 
-    if (elem.querySelector('.main-container') !== null) {
-      this.parseFromPage(task, elem);
-    } else {
+    if (elem.querySelector('#lentille-context') !== null) {
       this.parseFromScript(task, elem);
+    } else {
+      this.parseFromPage(task, elem);
     }
 
     return task.build();
@@ -45,7 +45,7 @@ export class LuoguProblemParser extends Parser {
     const script = elem.querySelector('#lentille-context').textContent;
     const data = JSON.parse(script).data.problem;
 
-    task.setName(`${data.pid} ${data.title}`.trim());
+    task.setName(`${data.pid} ${data.name}`.trim());
 
     task.setTimeLimit(Math.max(...data.limits.time));
     task.setMemoryLimit(Math.max(...data.limits.memory) / 1024);


### PR DESCRIPTION
Fix Luogu parser after the new frontend update.

- Prioritize #lentille-context JSON over .main-container DOM parsing
- Update JSON field data.title → data.name
- Update contest link selector: div.title > a.title → div.title > a

Closes #763, closes #764, closes #765