### PR TITLE
Restore @types auto-discovery after TypeScript 6 upgrade

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,6 +4,7 @@
     "moduleResolution": "Bundler",
     "target": "ES2022",
     "strict": true,
-    "strictNullChecks": false
+    "strictNullChecks": false,
+    "types": ["jest", "node", "webextension-polyfill"]
   }
 }


### PR DESCRIPTION
## Summary
After the bump to TypeScript 6.0.3 (in 2.65.0), `pnpm lint:tsc` fails on master and on every open PR:

```
tests/parsers.spec.ts(61,3): error TS2304: Cannot find name 'expect'.
tests/parsers.spec.ts(97,1): error TS2304: Cannot find name 'beforeAll'.
tests/parsers.spec.ts(117,1): error TS2304: Cannot find name 'afterAll'.
tests/parsers.spec.ts(129,7): error TS2593: Cannot find name 'test'. Do you need to install type definitions for a test runner? ...
```

TypeScript 6 no longer auto-includes packages under `node_modules/@types` when no `types` array is configured (with our `moduleResolution: "bundler"`), so the global declarations from `@types/jest` stop being visible.

Adding the three `@types` packages this project actually depends on (`jest`, `node`, `webextension-polyfill`) to `compilerOptions.types` restores the previous behavior. This unblocks the Build workflow on master and on every open PR currently failing the same step.

## Test plan
- [x] `pnpm lint` passes locally (was failing on master without this change)
- [x] CI Build turns green on this PR