### PR TITLE
Update Wincent DragonByte archive URL after the site moved them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## Unreleased
+- Fix the Wincent DragonByte problem parser after archive problem URLs moved from `/static/<round>/<letter>_statement.html` to `/archive/<round>/<letter>/statement`
+
 ## [2.65.0](https://github.com/jmerle/competitive-companion/releases/tag/2.65.0) (2026-06-29)
 - Add support for Wincent DragonByte (thanks [@EgorKulikov](https://github.com/EgorKulikov))
 - Fix the Luogu problem parser reading the lower bound of a per-testdata time-limit range (e.g. "500ms ~ 3.00s" was treated as 500s instead of 3s) and set the contest name as the group when parsing contest-scoped problem URLs (thanks [@EgorKulikov](https://github.com/EgorKulikov))

--- a/src/parsers/problem/WincentDragonByteProblemParser.ts
+++ b/src/parsers/problem/WincentDragonByteProblemParser.ts
@@ -6,7 +6,7 @@ import { Parser } from '../Parser';
 
 export class WincentDragonByteProblemParser extends Parser {
   public getMatchPatterns(): string[] {
-    return ['https://wincentdragonbyte.com/problem/*', 'https://wincentdragonbyte.com/static/*/*_statement.html'];
+    return ['https://wincentdragonbyte.com/problem/*', 'https://wincentdragonbyte.com/archive/*/*/statement'];
   }
 
   public async parse(url: string, html: string): Promise<Sendable> {
@@ -14,7 +14,7 @@ export class WincentDragonByteProblemParser extends Parser {
     const task = new TaskBuilder('Wincent DragonByte').setUrl(url);
 
     const liveMatch = /\/problem\/([^/?#]+)/.exec(url);
-    const archiveMatch = /\/static\/([^/]+)\/([^_/]+)_statement\.html/.exec(url);
+    const archiveMatch = /\/archive\/([^/]+)\/([^/]+)\/statement/.exec(url);
     const letter = liveMatch !== null ? liveMatch[1] : archiveMatch !== null ? archiveMatch[2] : '';
 
     const heading = elem.querySelector('#problem_statement h1, h1');


### PR DESCRIPTION
## Summary

Wincent DragonByte moved archive problems from
`https://wincentdragonbyte.com/static/<round>/<letter>_statement.html`
to `https://wincentdragonbyte.com/archive/<round>/<letter>/statement`
(the old URL now returns 404, e.g. `https://wincentdragonbyte.com/archive/qual2026/S/statement`).

Point the archive match pattern and the URL-decoding regex at the new scheme. The live `/problem/<letter>` path is unchanged and the archive page's DOM (h1 title, `table.io` samples, `#problem_statement` container) is the same as before, so nothing else needs to move.

## Test plan

- [x] Fetch `https://wincentdragonbyte.com/archive/qual2026/S/statement` and run `WincentDragonByteProblemParser` against the rendered DOM — parses `"S: Subtract First Digit"`, group `"Wincent DragonByte - Qualification 2026"`, both sample tests, `MultiNumber` test type.
- [x] Confirmed the old `/static/<round>/<letter>_statement.html` URL returns 404 and the new `/archive/<round>/<letter>/statement` URL returns 200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)